### PR TITLE
feat: support live preview

### DIFF
--- a/ast-grep.el
+++ b/ast-grep.el
@@ -48,7 +48,6 @@
 (declare-function consult--async-throttle "consult")
 (declare-function consult--read "consult")
 (declare-function consult--lookup-member "consult")
-(declare-function consult--jump-state "consult")
 (declare-function consult--file-preview "consult")
 
 (defgroup ast-grep nil


### PR DESCRIPTION
- set `:initial` such that user can directly type to filter with out typing another `#`
- support live preview using `consult--file-preview`