### PR TITLE
Fix consult async path when ivy-mode is active

### DIFF
--- a/ast-grep.el
+++ b/ast-grep.el
@@ -73,6 +73,25 @@ the command being executed, working directory, and raw output."
   :type 'integer
   :group 'ast-grep)
 
+(defcustom ast-grep-search-backend 'auto
+  "Backend for ast-grep search.
+`auto' uses consult async when available and ivy-mode is not active,
+falling back to sync completing-read otherwise.
+`consult' forces consult async search.
+`sync' forces synchronous completing-read search."
+  :type '(choice (const :tag "Auto-detect" auto)
+                 (const :tag "Consult async" consult)
+                 (const :tag "Sync completing-read" sync))
+  :group 'ast-grep)
+
+(defun ast-grep--use-consult-p ()
+  "Return non-nil if consult async search should be used."
+  (pcase ast-grep-search-backend
+    ('consult (require 'consult nil t))
+    ('sync nil)
+    ('auto (and (require 'consult nil t)
+                (not (bound-and-true-p ivy-mode))))))
+
 ;;; Internal variables
 
 (defvar ast-grep-history nil
@@ -264,7 +283,7 @@ Example patterns:
   
   (let ((search-dir (or directory default-directory)))
     (when-let ((selection
-                (if (require 'consult nil t)
+                (if (ast-grep--use-consult-p)
                     (ast-grep--search-async pattern search-dir)
                   (ast-grep--search-sync pattern search-dir))))
       (ast-grep--goto-match selection))))

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -69,6 +69,26 @@
     (let ((candidates (ast-grep--candidates "pattern")))
       (should-not candidates))))
 
+;;; Backend detection tests
+
+(ert-deftest ast-grep-test-use-consult-p-sync-backend ()
+  "Test that sync backend always returns nil."
+  (let ((ast-grep-search-backend 'sync))
+    (should-not (ast-grep--use-consult-p))))
+
+(ert-deftest ast-grep-test-use-consult-p-auto-with-ivy ()
+  "Test that auto backend returns nil when ivy-mode is active."
+  (let ((ast-grep-search-backend 'auto)
+        (ivy-mode t))
+    (should-not (ast-grep--use-consult-p))))
+
+(ert-deftest ast-grep-test-use-consult-p-auto-without-consult ()
+  "Test that auto backend returns nil when consult is unavailable."
+  (let ((ast-grep-search-backend 'auto))
+    ;; consult is not available in test environment
+    ;; so (require 'consult nil t) returns nil
+    (should-not (ast-grep--use-consult-p))))
+
 (provide 'test-ast-grep)
 
 ;;; ast-grep-test.el ends here


### PR DESCRIPTION
## Summary
- Add `ast-grep-search-backend` defcustom (`auto`/`consult`/`sync`) to control search backend
- In `auto` mode, detect `ivy-mode` and fall back to sync `completing-read` (consult async doesn't work with ivy)
- Add `ast-grep--use-consult-p` helper for backend selection logic

Closes #4

## Root Cause
`(require 'consult nil t)` only checks if consult is loadable, not whether it's the active completion framework. When users have both consult and ivy/counsel installed, the async path is taken but consult's `#pattern#` syntax doesn't work with ivy, causing "match required" errors.

## Test plan
- [x] `ast-grep-test-use-consult-p-sync-backend` — sync backend always returns nil
- [x] `ast-grep-test-use-consult-p-auto-with-ivy` — auto backend returns nil when ivy-mode is active
- [x] `ast-grep-test-use-consult-p-auto-without-consult` — auto backend returns nil when consult unavailable
- [x] All 10 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)