### PR TITLE
Add rewrite support for AST pattern search-and-replace

### DIFF
--- a/ast-grep.el
+++ b/ast-grep.el
@@ -103,6 +103,17 @@ the command being executed, working directory, and raw output."
       (push (expand-file-name directory) args))
     (append cmd (reverse args))))
 
+(defun ast-grep--build-rewrite-command (pattern replacement &optional directory)
+  "Build ast-grep rewrite command with PATTERN, REPLACEMENT and DIRECTORY."
+  (let ((cmd (list ast-grep-executable "run"))
+        (args '()))
+    (push (format "--pattern=%s" pattern) args)
+    (push (format "--rewrite=%s" replacement) args)
+    (push "--update-all" args)
+    (when directory
+      (push (expand-file-name directory) args))
+    (append cmd (reverse args))))
+
 ;;; Core functions (kept for testing and internal use)
 
 (defun ast-grep--run-command (pattern &optional directory)
@@ -127,6 +138,30 @@ the command being executed, working directory, and raw output."
           (if (zerop exit-code)
               output
             (error "The ast-grep failed with exit code %d: %s"
+                   exit-code output)))))))
+
+(defun ast-grep--run-rewrite-command (pattern replacement &optional directory)
+  "Run ast-grep rewrite with PATTERN and REPLACEMENT in DIRECTORY.
+Returns the command output string."
+  (unless (ast-grep--executable-available-p)
+    (error "The ast-grep executable not found. Please install ast-grep"))
+  (let ((default-directory (or directory default-directory))
+        (command (ast-grep--build-rewrite-command pattern replacement directory)))
+    (when ast-grep-debug
+      (message "Debug: Running rewrite command: %s"
+               (mapconcat #'shell-quote-argument command " "))
+      (message "Debug: Working directory: %s" default-directory))
+    (with-temp-buffer
+      (let ((exit-code (apply #'call-process
+                              (car command) nil t nil
+                              (cdr command))))
+        (let ((output (buffer-string)))
+          (when ast-grep-debug
+            (message "Debug: Rewrite output: %s" output)
+            (message "Debug: Exit code: %d" exit-code))
+          (if (zerop exit-code)
+              output
+            (error "The ast-grep rewrite failed with exit code %d: %s"
                    exit-code output)))))))
 
 (defun ast-grep--parse-json-output (output)
@@ -301,7 +336,64 @@ Otherwise sync with `completing-read'."
                      (read-directory-name "Directory: ")))
   (ast-grep-search pattern directory))
 
+;;;###autoload
+(defun ast-grep-rewrite (pattern replacement &optional directory)
+  "Rewrite code matching ast-grep PATTERN with REPLACEMENT in DIRECTORY.
+
+PATTERN is an ast-grep pattern string.
+REPLACEMENT is the replacement string (can use meta-variables from PATTERN).
+DIRECTORY defaults to current directory if not specified.
+
+First searches for matches to show the user what will change,
+then applies the rewrite after confirmation.
+
+Example:
+  Pattern:     \\='console.log($A)\\='
+  Replacement: \\='logger.info($A)\\='"
+  (interactive (list (read-string "ast-grep pattern: " nil 'ast-grep-history)
+                     (read-string "Replacement: ")
+                     nil))
+  (unless (ast-grep--executable-available-p)
+    (error "The ast-grep executable not found. Please install ast-grep"))
+  (let* ((search-dir (or directory default-directory))
+         (candidates (ast-grep--candidates pattern search-dir))
+         (count (length candidates)))
+    (if (zerop count)
+        (message "No matches found for pattern: %s" pattern)
+      (when (yes-or-no-p (format "Rewrite %d match%s? " count (if (= count 1) "" "es")))
+        (ast-grep--run-rewrite-command pattern replacement search-dir)
+        (ast-grep--revert-modified-buffers search-dir)
+        (message "Rewrote %d match%s." count (if (= count 1) "" "es"))))))
+
+;;;###autoload
+(defun ast-grep-rewrite-project (pattern replacement)
+  "Rewrite code matching ast-grep PATTERN with REPLACEMENT in current project."
+  (interactive (list (read-string "ast-grep pattern (project): " nil 'ast-grep-history)
+                     (read-string "Replacement: ")))
+  (if-let ((project-root (ast-grep--project-root)))
+      (ast-grep-rewrite pattern replacement project-root)
+    (error "Not in a project")))
+
+;;;###autoload
+(defun ast-grep-rewrite-directory (pattern replacement directory)
+  "Rewrite code matching ast-grep PATTERN with REPLACEMENT in DIRECTORY."
+  (interactive (list (read-string "ast-grep pattern: " nil 'ast-grep-history)
+                     (read-string "Replacement: ")
+                     (read-directory-name "Directory: ")))
+  (ast-grep-rewrite pattern replacement directory))
+
 ;;; Helper functions
+
+(defun ast-grep--revert-modified-buffers (directory)
+  "Revert buffers visiting files under DIRECTORY that have changed on disk."
+  (let ((dir (expand-file-name directory)))
+    (dolist (buf (buffer-list))
+      (when-let ((file (buffer-file-name buf)))
+        (when (and (string-prefix-p dir file)
+                   (not (buffer-modified-p buf))
+                   (not (verify-visited-file-modtime buf)))
+          (with-current-buffer buf
+            (revert-buffer t t t)))))))
 
 (defun ast-grep--goto-match (match)
   "Go to the location specified by MATCH string.

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -69,6 +69,28 @@
     (let ((candidates (ast-grep--candidates "pattern")))
       (should-not candidates))))
 
+(ert-deftest ast-grep-test-build-rewrite-command ()
+  "Test rewrite command building."
+  (let ((ast-grep-executable "ast-grep"))
+    (should (equal (ast-grep--build-rewrite-command "pattern" "replacement")
+                   '("ast-grep" "run" "--pattern=pattern" "--rewrite=replacement" "--update-all")))
+    (should (equal (ast-grep--build-rewrite-command "pattern" "replacement" "/path")
+                   '("ast-grep" "run" "--pattern=pattern" "--rewrite=replacement" "--update-all" "/path")))))
+
+(ert-deftest ast-grep-test-rewrite-no-matches ()
+  "Test rewrite with no matches does nothing."
+  (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+             (lambda () t))
+            ((symbol-function 'ast-grep--candidates)
+             (lambda (&rest _args) nil)))
+    ;; Should not error, just message
+    (ast-grep-rewrite "nonexistent" "replacement" default-directory)))
+
+(ert-deftest ast-grep-test-revert-modified-buffers ()
+  "Test that revert function doesn't error on empty buffer list."
+  ;; Should not error when called with a directory
+  (ast-grep--revert-modified-buffers temporary-file-directory))
+
 (provide 'test-ast-grep)
 
 ;;; ast-grep-test.el ends here


### PR DESCRIPTION
## Summary
- Add `ast-grep-rewrite`, `ast-grep-rewrite-project`, and `ast-grep-rewrite-directory` interactive commands
- Search for matches first, show count, ask for `yes-or-no-p` confirmation, then apply via `ast-grep run --pattern --rewrite --update-all`
- Auto-revert affected open buffers after rewrite

Closes #3

## Usage
```
M-x ast-grep-rewrite
  Pattern: console.log($A)
  Replacement: logger.info($A)
  Rewrite 7 matches? (yes or no)
```

## New functions
- `ast-grep--build-rewrite-command` — builds CLI command with `--rewrite` and `--update-all`
- `ast-grep--run-rewrite-command` — executes rewrite via `call-process`
- `ast-grep--revert-modified-buffers` — reverts open buffers whose files changed on disk
- `ast-grep-rewrite` / `ast-grep-rewrite-project` / `ast-grep-rewrite-directory` — interactive commands

## Test plan
- [x] `ast-grep-test-build-rewrite-command` — command construction with/without directory
- [x] `ast-grep-test-rewrite-no-matches` — no-match case messages without error
- [x] `ast-grep-test-revert-modified-buffers` — revert helper doesn't error
- [x] All 10 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)