### PR TITLE
feat(rewrite): add interactive search-and-rewrite commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,7 @@ An Emacs interface to [[https://github.com/ast-grep/ast-grep][ast-grep]], a CLI 
 - Integration with completing-read frameworks (Vertico, etc.)
 - Streaming JSON parsing for efficient processing
 - Async search with live results when consult is available
+- Interactive rewrite across files (~project-query-replace-regexp~ style)
 
 ** Requirements
 
@@ -64,8 +65,15 @@ Add to your ~packages.el~:
 *** Interactive Commands
 
 - ~ast-grep-search~ - Search for patterns in current directory
-- ~ast-grep-project~ - Search for patterns in current project  
+- ~ast-grep-project~ - Search for patterns in current project
 - ~ast-grep-directory~ - Search for patterns in specified directory
+- ~ast-grep-rewrite~ - Interactive search-and-rewrite in current directory
+- ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
+
+~ast-grep-rewrite~ prompts for a pattern and a replacement template, then
+walks each match asking ~y~/~n~/~!~/~q~ (yes / skip / yes-to-all / quit),
+mirroring ~project-query-replace-regexp~. Modified buffers are left for
+you to save with ~save-some-buffers~.
 
 *** Minor Mode
 

--- a/README.org
+++ b/README.org
@@ -73,9 +73,8 @@ Add to your ~packages.el~:
 ~ast-grep-rewrite~ prompts for a pattern and a replacement template,
 then walks each match asking ~y~/~n~/~!~/~q~ (yes / skip /
 apply-all-remaining / quit), following ~query-replace~ conventions like
-~project-query-replace-regexp~. Files that received at least one
-replacement are saved automatically when the session ends; other
-modified buffers are left untouched.
+~project-query-replace-regexp~. Modified buffers are left for you to
+save with ~M-x save-some-buffers~ (~C-x s~).
 
 *** Minor Mode
 

--- a/README.org
+++ b/README.org
@@ -71,9 +71,11 @@ Add to your ~packages.el~:
 - ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
 
 ~ast-grep-rewrite~ prompts for a pattern and a replacement template, then
-walks each match asking ~y~/~n~/~!~/~q~ (yes / skip / yes-to-all / quit),
-mirroring ~project-query-replace-regexp~. Modified buffers are left for
-you to save with ~save-some-buffers~.
+walks each match asking ~y~/~n~/~A~/~q~ (yes / skip / apply-all-remaining
+/ quit), mirroring ~project-query-replace-regexp~ in flow. ~!~ is also
+accepted as an alias for ~A~. Files that received at least one
+replacement are saved automatically when the session ends; other
+modified buffers are left untouched.
 
 *** Minor Mode
 

--- a/README.org
+++ b/README.org
@@ -70,10 +70,10 @@ Add to your ~packages.el~:
 - ~ast-grep-rewrite~ - Interactive search-and-rewrite in current directory
 - ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
 
-~ast-grep-rewrite~ prompts for a pattern and a replacement template, then
-walks each match asking ~y~/~n~/~A~/~q~ (yes / skip / apply-all-remaining
-/ quit), mirroring ~project-query-replace-regexp~ in flow. ~!~ is also
-accepted as an alias for ~A~. Files that received at least one
+~ast-grep-rewrite~ prompts for a pattern and a replacement template,
+then walks each match asking ~y~/~n~/~!~/~q~ (yes / skip /
+apply-all-remaining / quit), following ~query-replace~ conventions like
+~project-query-replace-regexp~. Files that received at least one
 replacement are saved automatically when the session ends; other
 modified buffers are left untouched.
 

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -78,6 +78,9 @@ the command being executed, working directory, and raw output."
 (defvar ast-grep-history nil
   "History list for ast-grep searches.")
 
+(defvar ast-grep-rewrite-history nil
+  "History list for ast-grep rewrite templates.")
+
 (defvar ast-grep--current-process nil
   "Current ast-grep process.")
 
@@ -92,11 +95,16 @@ the command being executed, working directory, and raw output."
   (when-let ((project (project-current)))
     (project-root project)))
 
-(defun ast-grep--build-command (pattern &optional directory)
-  "Build ast-grep command with PATTERN and DIRECTORY."
+(defun ast-grep--build-command (pattern &optional directory rewrite)
+  "Build ast-grep command with PATTERN.
+Optional DIRECTORY restricts the search path.  Optional REWRITE adds
+a `--rewrite' template so ast-grep emits replacement text alongside
+each match."
   (let ((cmd (list ast-grep-executable "run"))
         (args '()))
     (push (format "--pattern=%s" pattern) args)
+    (when rewrite
+      (push (format "--rewrite=%s" rewrite) args))
     (push "--json=stream" args)
     (when directory
       ;; Expand ~ and environment variables in directory path
@@ -174,6 +182,125 @@ the command being executed, working directory, and raw output."
   (when (and output (not (string-empty-p output)))
     (let ((lines (split-string output "\n" t)))
       (delq nil (mapcar #'ast-grep--parse-stream-line lines)))))
+
+;;; Rewrite functions
+
+(defun ast-grep--parse-rewrite-line (line)
+  "Parse a single JSON LINE from ast-grep rewrite output.
+Return a plist with :file, :start-line, :start-column, :end-line,
+:end-column, :text, :replacement, or nil for malformed input."
+  (when (and line (not (string-empty-p line)))
+    (condition-case nil
+        (let* ((result (json-parse-string line :object-type 'plist))
+               (range (plist-get result :range))
+               (start (plist-get range :start))
+               (end (plist-get range :end)))
+          (list :file (plist-get result :file)
+                :start-line (plist-get start :line)
+                :start-column (plist-get start :column)
+                :end-line (plist-get end :line)
+                :end-column (plist-get end :column)
+                :text (plist-get result :text)
+                :replacement (plist-get result :replacement)))
+      (error nil))))
+
+(defun ast-grep--collect-rewrites (pattern rewrite directory)
+  "Run ast-grep with PATTERN and REWRITE in DIRECTORY.
+Return a list of match plists as produced by
+`ast-grep--parse-rewrite-line'."
+  (unless (ast-grep--executable-available-p)
+    (error "The ast-grep executable not found. Please install ast-grep"))
+  (let* ((default-directory (or directory default-directory))
+         (command (ast-grep--build-command pattern directory rewrite))
+         (output (with-temp-buffer
+                   (let ((exit-code (apply #'call-process
+                                           (car command) nil t nil
+                                           (cdr command))))
+                     (when ast-grep-debug
+                       (message "Debug: rewrite command: %s"
+                                (mapconcat #'shell-quote-argument command " "))
+                       (message "Debug: rewrite exit code: %d" exit-code))
+                     (buffer-string)))))
+    (delq nil (mapcar #'ast-grep--parse-rewrite-line
+                      (split-string output "\n" t)))))
+
+(defun ast-grep--match-region (match)
+  "Compute (BEG . END) buffer positions in current buffer for MATCH.
+Uses `forward-char' rather than `move-to-column' because ast-grep
+reports character-index columns, while `move-to-column' uses visual
+columns that change with `tab-width' and double-width characters."
+  (save-excursion
+    (goto-char (point-min))
+    (forward-line (plist-get match :start-line))
+    (forward-char (plist-get match :start-column))
+    (let ((beg (point)))
+      (goto-char (point-min))
+      (forward-line (plist-get match :end-line))
+      (forward-char (plist-get match :end-column))
+      (cons beg (point)))))
+
+(defun ast-grep--rewrite-sort (matches)
+  "Return MATCHES sorted by file ascending, position descending.
+Reversing within a file lets edits be applied without invalidating
+the offsets of earlier matches in the same file."
+  (sort (copy-sequence matches)
+        (lambda (a b)
+          (let ((fa (plist-get a :file))
+                (fb (plist-get b :file)))
+            (cond
+             ((not (equal fa fb)) (string< fa fb))
+             ((/= (plist-get a :start-line) (plist-get b :start-line))
+              (> (plist-get a :start-line) (plist-get b :start-line)))
+             (t (> (plist-get a :start-column)
+                   (plist-get b :start-column))))))))
+
+(defun ast-grep--apply-rewrites (matches)
+  "Walk MATCHES interactively, applying replacements after confirmation.
+The prompt accepts y (yes), n (skip), ! (yes to all remaining),
+q (quit).  Modified buffers are left for the user to save."
+  (let ((replaced 0)
+        (skipped 0)
+        (all nil)
+        (quit nil))
+    (dolist (m (ast-grep--rewrite-sort matches))
+      (unless quit
+        (let* ((file (plist-get m :file))
+               (buf (or (find-buffer-visiting file)
+                        (find-file-noselect file))))
+          (with-current-buffer buf
+            (let* ((region (ast-grep--match-region m))
+                   (beg (car region))
+                   (end (cdr region))
+                   (overlay (make-overlay beg end)))
+              (overlay-put overlay 'face 'query-replace)
+              (overlay-put overlay 'priority 1001)
+              (unwind-protect
+                  (progn
+                    (pop-to-buffer buf)
+                    (goto-char beg)
+                    (let ((choice
+                           (if all
+                               ?y
+                             (condition-case nil
+                                 (read-char-choice
+                                  (format "Replace `%s' with `%s'? (y/n/!/q) "
+                                          (plist-get m :text)
+                                          (plist-get m :replacement))
+                                  '(?y ?n ?! ?q))
+                               (quit ?q)))))
+                      (pcase choice
+                        ((or ?y ?!)
+                         (when (eq choice ?!) (setq all t))
+                         (goto-char beg)
+                         (delete-region beg end)
+                         (insert (plist-get m :replacement))
+                         (setq replaced (1+ replaced)))
+                        (?n (setq skipped (1+ skipped)))
+                        (?q (setq quit t)))))
+                (delete-overlay overlay)))))))
+    (message "Replaced %d match(es), skipped %d%s"
+             replaced skipped
+             (if quit " (quit)" ""))))
 
 ;;; Async functions (require consult)
 
@@ -290,6 +417,40 @@ Equivalent to `ast-grep-search' with the project root as directory."
 DIRECTORY supports `~' expansion."
   (interactive (list (read-directory-name "Directory: ")))
   (ast-grep-search directory))
+
+;;;###autoload
+(defun ast-grep-rewrite (&optional directory)
+  "Search for ast-grep patterns in DIRECTORY and rewrite them interactively.
+
+Prompts for a pattern and a replacement template, then walks each
+match asking for confirmation, similar to
+`project-query-replace-regexp'.  The prompt accepts y (yes), n
+\(skip), ! (yes to all remaining), q (quit).  Modified buffers are
+left for the user to save.
+
+DIRECTORY defaults to the current directory."
+  (interactive)
+  (unless (ast-grep--executable-available-p)
+    (error "The ast-grep executable not found. Please install ast-grep"))
+  (let* ((search-dir (or directory default-directory))
+         (pattern (read-string "ast-grep pattern: " nil 'ast-grep-history))
+         (rewrite (read-string (format "Rewrite `%s' with: " pattern)
+                               nil 'ast-grep-rewrite-history))
+         (matches (ast-grep--collect-rewrites pattern rewrite search-dir)))
+    (if (null matches)
+        (message "No matches for pattern: %s" pattern)
+      (ast-grep--apply-rewrites matches))))
+
+;;;###autoload
+(defun ast-grep-rewrite-project ()
+  "Rewrite ast-grep patterns across the current project.
+
+Requires being in a project (detected via `project.el').
+Equivalent to `ast-grep-rewrite' with the project root as directory."
+  (interactive)
+  (if-let ((project-root (ast-grep--project-root)))
+      (ast-grep-rewrite project-root)
+    (error "Not in a project")))
 
 ;;; Helper functions
 

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -256,9 +256,10 @@ the offsets of earlier matches in the same file."
 
 (defun ast-grep--apply-rewrites (matches)
   "Walk MATCHES interactively, applying replacements after confirmation.
-The prompt accepts y (yes), n (skip), A or ! (apply this and all
-remaining), q (quit).  Affected file-visiting buffers are saved
-after the session completes; other modified buffers are untouched."
+The prompt accepts y (yes), n (skip), ! (apply this and all
+remaining), q (quit), following `query-replace' conventions.
+Affected file-visiting buffers are saved after the session
+completes; other modified buffers are untouched."
   (let ((replaced 0)
         (skipped 0)
         (modified-buffers nil)
@@ -285,14 +286,14 @@ after the session completes; other modified buffers are untouched."
                                ?y
                              (condition-case nil
                                  (read-char-choice
-                                  (format "Replace `%s' with `%s'? (y/n/A/q) "
+                                  (format "Replace `%s' with `%s'? (y/n/!/q) "
                                           (plist-get m :text)
                                           (plist-get m :replacement))
-                                  '(?y ?n ?A ?a ?! ?q))
+                                  '(?y ?n ?! ?q))
                                (quit ?q)))))
                       (pcase choice
-                        ((or ?y ?A ?a ?!)
-                         (when (memq choice '(?A ?a ?!)) (setq all t))
+                        ((or ?y ?!)
+                         (when (eq choice ?!) (setq all t))
                          (goto-char beg)
                          (delete-region beg end)
                          (insert (plist-get m :replacement))
@@ -438,9 +439,9 @@ DIRECTORY supports `~' expansion."
 Prompts for a pattern and a replacement template, then walks each
 match asking for confirmation, similar to
 `project-query-replace-regexp'.  The prompt accepts y (yes), n
-\(skip), A or ! (apply this and all remaining), q (quit).  Files
-that received at least one replacement are saved automatically when
-the session ends.
+\(skip), ! (apply this and all remaining), q (quit).  Files that
+received at least one replacement are saved automatically when the
+session ends.
 
 DIRECTORY defaults to the current directory."
   (interactive)

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -256,10 +256,12 @@ the offsets of earlier matches in the same file."
 
 (defun ast-grep--apply-rewrites (matches)
   "Walk MATCHES interactively, applying replacements after confirmation.
-The prompt accepts y (yes), n (skip), ! (yes to all remaining),
-q (quit).  Modified buffers are left for the user to save."
+The prompt accepts y (yes), n (skip), A or ! (apply this and all
+remaining), q (quit).  Affected file-visiting buffers are saved
+after the session completes; other modified buffers are untouched."
   (let ((replaced 0)
         (skipped 0)
+        (modified-buffers nil)
         (all nil)
         (quit nil))
     (dolist (m (ast-grep--rewrite-sort matches))
@@ -283,23 +285,34 @@ q (quit).  Modified buffers are left for the user to save."
                                ?y
                              (condition-case nil
                                  (read-char-choice
-                                  (format "Replace `%s' with `%s'? (y/n/!/q) "
+                                  (format "Replace `%s' with `%s'? (y/n/A/q) "
                                           (plist-get m :text)
                                           (plist-get m :replacement))
-                                  '(?y ?n ?! ?q))
+                                  '(?y ?n ?A ?a ?! ?q))
                                (quit ?q)))))
                       (pcase choice
-                        ((or ?y ?!)
-                         (when (eq choice ?!) (setq all t))
+                        ((or ?y ?A ?a ?!)
+                         (when (memq choice '(?A ?a ?!)) (setq all t))
                          (goto-char beg)
                          (delete-region beg end)
                          (insert (plist-get m :replacement))
+                         (unless (memq buf modified-buffers)
+                           (push buf modified-buffers))
                          (setq replaced (1+ replaced)))
                         (?n (setq skipped (1+ skipped)))
                         (?q (setq quit t)))))
                 (delete-overlay overlay)))))))
-    (message "Replaced %d match(es), skipped %d%s"
-             replaced skipped
+    ;; Save the buffers we edited.  Other modified buffers are left alone.
+    (dolist (b modified-buffers)
+      (when (and (buffer-live-p b)
+                 (buffer-file-name b))
+        (with-current-buffer b
+          (when (buffer-modified-p)
+            (save-buffer)))))
+    (message "Replaced %d match(es) in %d file(s); skipped %d%s"
+             replaced
+             (length modified-buffers)
+             skipped
              (if quit " (quit)" ""))))
 
 ;;; Async functions (require consult)
@@ -425,8 +438,9 @@ DIRECTORY supports `~' expansion."
 Prompts for a pattern and a replacement template, then walks each
 match asking for confirmation, similar to
 `project-query-replace-regexp'.  The prompt accepts y (yes), n
-\(skip), ! (yes to all remaining), q (quit).  Modified buffers are
-left for the user to save.
+\(skip), A or ! (apply this and all remaining), q (quit).  Files
+that received at least one replacement are saved automatically when
+the session ends.
 
 DIRECTORY defaults to the current directory."
   (interactive)

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2025 SunskyXH
 
 ;; Author: SunskyxXH <sunskyxh@gmail.com>
-;; Version: 0.2.0
+;; Version: 0.3.0
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools, matching
 ;; URL: https://github.com/sunskyxh/ast-grep.el

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -258,8 +258,9 @@ the offsets of earlier matches in the same file."
   "Walk MATCHES interactively, applying replacements after confirmation.
 The prompt accepts y (yes), n (skip), ! (apply this and all
 remaining), q (quit), following `query-replace' conventions.
-Affected file-visiting buffers are saved after the session
-completes; other modified buffers are untouched."
+Modified buffers are left for the user to save with
+`save-some-buffers' (\\[save-some-buffers]), matching
+`project-query-replace-regexp' behaviour."
   (let ((replaced 0)
         (skipped 0)
         (modified-buffers nil)
@@ -303,18 +304,17 @@ completes; other modified buffers are untouched."
                         (?n (setq skipped (1+ skipped)))
                         (?q (setq quit t)))))
                 (delete-overlay overlay)))))))
-    ;; Save the buffers we edited.  Other modified buffers are left alone.
-    (dolist (b modified-buffers)
-      (when (and (buffer-live-p b)
-                 (buffer-file-name b))
-        (with-current-buffer b
-          (when (buffer-modified-p)
-            (save-buffer)))))
-    (message "Replaced %d match(es) in %d file(s); skipped %d%s"
-             replaced
-             (length modified-buffers)
-             skipped
-             (if quit " (quit)" ""))))
+    (message
+     "%s"
+     (substitute-command-keys
+      (format "Replaced %d match(es) in %d file(s); skipped %d%s%s"
+              replaced
+              (length modified-buffers)
+              skipped
+              (if quit " (quit)" "")
+              (if modified-buffers
+                  "; use \\[save-some-buffers] to save"
+                ""))))))
 
 ;;; Async functions (require consult)
 
@@ -439,9 +439,8 @@ DIRECTORY supports `~' expansion."
 Prompts for a pattern and a replacement template, then walks each
 match asking for confirmation, similar to
 `project-query-replace-regexp'.  The prompt accepts y (yes), n
-\(skip), ! (apply this and all remaining), q (quit).  Files that
-received at least one replacement are saved automatically when the
-session ends.
+\(skip), ! (apply this and all remaining), q (quit).  Modified
+buffers are left for the user to save with `save-some-buffers'.
 
 DIRECTORY defaults to the current directory."
   (interactive)

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -373,44 +373,7 @@ and routes the chosen candidate through `ast-grep--goto-match'."
                               (plist-get m :replacement))))))
 
 (ert-deftest ast-grep-test-end-to-end-rewrite-applies-yes-to-all ()
-  "Driving the prompt with `A' rewrites every match and saves the file."
-  (skip-unless (ast-grep-test--ast-grep-available-p))
-  (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
-         (tmp-file (expand-file-name "sample.js" tmp-dir))
-         buf)
-    (unwind-protect
-        (progn
-          (copy-file ast-grep-test--sample-file tmp-file)
-          (cl-letf (((symbol-function 'read-string)
-                     (lambda (prompt &rest _)
-                       (cond
-                        ((string-prefix-p "ast-grep pattern" prompt)
-                         "console.log($A)")
-                        ((string-prefix-p "Rewrite" prompt)
-                         "logger.info($A)"))))
-                    ((symbol-function 'read-char-choice)
-                     (lambda (&rest _) ?A))
-                    ((symbol-function 'pop-to-buffer)
-                     (lambda (b &rest _) b)))
-            (ast-grep-rewrite tmp-dir))
-          (setq buf (find-buffer-visiting tmp-file))
-          (should buf)
-          ;; The buffer should be saved (not modified).
-          (with-current-buffer buf
-            (should-not (buffer-modified-p)))
-          ;; And the file on disk should reflect the rewrite.
-          (with-temp-buffer
-            (insert-file-contents tmp-file)
-            (let ((content (buffer-string)))
-              (should (string-match-p "logger\\.info(\"hello\")" content))
-              (should (string-match-p "logger\\.info(x)" content))
-              (should (string-match-p "logger\\.info(name)" content))
-              (should-not (string-match-p "console\\.log" content)))))
-      (when (and buf (buffer-live-p buf)) (kill-buffer buf))
-      (delete-directory tmp-dir t))))
-
-(ert-deftest ast-grep-test-end-to-end-rewrite-bang-is-alias-for-A ()
-  "`!' is accepted as a legacy alias for `A' (apply all)."
+  "Driving the prompt with `!' rewrites every match and saves the file."
   (skip-unless (ast-grep-test--ast-grep-available-p))
   (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
          (tmp-file (expand-file-name "sample.js" tmp-dir))
@@ -431,9 +394,18 @@ and routes the chosen candidate through `ast-grep--goto-match'."
                      (lambda (b &rest _) b)))
             (ast-grep-rewrite tmp-dir))
           (setq buf (find-buffer-visiting tmp-file))
+          (should buf)
+          ;; The buffer should be saved (not modified).
+          (with-current-buffer buf
+            (should-not (buffer-modified-p)))
+          ;; And the file on disk should reflect the rewrite.
           (with-temp-buffer
             (insert-file-contents tmp-file)
-            (should-not (string-match-p "console\\.log" (buffer-string)))))
+            (let ((content (buffer-string)))
+              (should (string-match-p "logger\\.info(\"hello\")" content))
+              (should (string-match-p "logger\\.info(x)" content))
+              (should (string-match-p "logger\\.info(name)" content))
+              (should-not (string-match-p "console\\.log" content)))))
       (when (and buf (buffer-live-p buf)) (kill-buffer buf))
       (delete-directory tmp-dir t))))
 

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -373,7 +373,8 @@ and routes the chosen candidate through `ast-grep--goto-match'."
                               (plist-get m :replacement))))))
 
 (ert-deftest ast-grep-test-end-to-end-rewrite-applies-yes-to-all ()
-  "Driving the prompt with `!' rewrites every match and saves the file."
+  "Driving the prompt with `!' rewrites every match in the buffer.
+The file on disk stays untouched; the user is expected to save."
   (skip-unless (ast-grep-test--ast-grep-available-p))
   (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
          (tmp-file (expand-file-name "sample.js" tmp-dir))
@@ -395,18 +396,23 @@ and routes the chosen candidate through `ast-grep--goto-match'."
             (ast-grep-rewrite tmp-dir))
           (setq buf (find-buffer-visiting tmp-file))
           (should buf)
-          ;; The buffer should be saved (not modified).
+          ;; Buffer should be modified (unsaved), matching
+          ;; `project-query-replace-regexp' semantics.
           (with-current-buffer buf
-            (should-not (buffer-modified-p)))
-          ;; And the file on disk should reflect the rewrite.
-          (with-temp-buffer
-            (insert-file-contents tmp-file)
+            (should (buffer-modified-p))
             (let ((content (buffer-string)))
               (should (string-match-p "logger\\.info(\"hello\")" content))
               (should (string-match-p "logger\\.info(x)" content))
               (should (string-match-p "logger\\.info(name)" content))
-              (should-not (string-match-p "console\\.log" content)))))
-      (when (and buf (buffer-live-p buf)) (kill-buffer buf))
+              (should-not (string-match-p "console\\.log" content))))
+          ;; File on disk should be untouched until the user saves.
+          (with-temp-buffer
+            (insert-file-contents tmp-file)
+            (should (string-match-p "console\\.log(\"hello\")"
+                                    (buffer-string)))))
+      (when (and buf (buffer-live-p buf))
+        (with-current-buffer buf (set-buffer-modified-p nil))
+        (kill-buffer buf))
       (delete-directory tmp-dir t))))
 
 (ert-deftest ast-grep-test-end-to-end-rewrite-quit-skips-remaining ()

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -71,6 +71,15 @@ TIMEOUT defaults to 5 seconds."
     (should (equal (ast-grep--build-command "pattern" "/path")
                    '("ast-grep" "run" "--pattern=pattern" "--json=stream" "/path")))))
 
+(ert-deftest ast-grep-test-build-command-with-rewrite ()
+  "Command should include --rewrite when REWRITE is provided."
+  (let ((ast-grep-executable "ast-grep"))
+    (should (equal (ast-grep--build-command "pat" nil "fix")
+                   '("ast-grep" "run" "--pattern=pat" "--rewrite=fix" "--json=stream")))
+    (should (equal (ast-grep--build-command "pat" "/path" "fix")
+                   '("ast-grep" "run" "--pattern=pat" "--rewrite=fix"
+                     "--json=stream" "/path")))))
+
 (ert-deftest ast-grep-test-parse-json-output ()
   "Test JSON output parsing."
   (let ((json-output "[{\"file\":\"test.js\",\"range\":{\"start\":{\"line\":0,\"column\":0}},\"text\":\"console.log()\"}]"))
@@ -97,6 +106,52 @@ TIMEOUT defaults to 5 seconds."
                    '("a.js:1:0:x" "b.js:3:4:y"))))
   (should-not (ast-grep--parse-stream-output nil))
   (should-not (ast-grep--parse-stream-output "")))
+
+;;; Rewrite parser tests
+
+(ert-deftest ast-grep-test-parse-rewrite-line ()
+  "Parse a JSON line that includes end position and replacement."
+  (let* ((line (concat "{\"file\":\"a.js\","
+                       "\"range\":{\"start\":{\"line\":0,\"column\":0},"
+                       "\"end\":{\"line\":0,\"column\":13}},"
+                       "\"text\":\"console.log()\","
+                       "\"replacement\":\"logger.info()\"}"))
+         (m (ast-grep--parse-rewrite-line line)))
+    (should (equal (plist-get m :file) "a.js"))
+    (should (= (plist-get m :start-line) 0))
+    (should (= (plist-get m :start-column) 0))
+    (should (= (plist-get m :end-line) 0))
+    (should (= (plist-get m :end-column) 13))
+    (should (equal (plist-get m :text) "console.log()"))
+    (should (equal (plist-get m :replacement) "logger.info()")))
+  (should-not (ast-grep--parse-rewrite-line nil))
+  (should-not (ast-grep--parse-rewrite-line ""))
+  (should-not (ast-grep--parse-rewrite-line "not-json")))
+
+(ert-deftest ast-grep-test-rewrite-sort-reverses-within-file ()
+  "Matches in the same file are sorted in reverse position order."
+  (let* ((a (list :file "a.js" :start-line 0 :start-column 0))
+         (b (list :file "a.js" :start-line 2 :start-column 4))
+         (c (list :file "a.js" :start-line 2 :start-column 8))
+         (d (list :file "b.js" :start-line 0 :start-column 0))
+         (sorted (ast-grep--rewrite-sort (list a b c d))))
+    (should (equal sorted (list c b a d)))))
+
+(ert-deftest ast-grep-test-match-region-uses-character-columns ()
+  "Region must be computed by character index, not visual column.
+A tab at the start of the line would offset `move-to-column' but
+`forward-char' lands on the correct character."
+  (with-temp-buffer
+    (insert "\tconsole.log(x);\n")
+    (let* ((match (list :start-line 0 :start-column 1
+                        :end-line 0 :end-column 15))
+           (region (ast-grep--match-region match)))
+      ;; start-column 1 must land just after the tab (position 2 in
+      ;; 1-indexed buffer coords), not in the middle of the tab's
+      ;; visual span.
+      (should (= (car region) 2))
+      (should (equal (buffer-substring (car region) (cdr region))
+                     "console.log(x)")))))
 
 ;;; Async builder tests
 
@@ -299,6 +354,88 @@ and routes the chosen candidate through `ast-grep--goto-match'."
         (unless buffer-before
           (when-let ((buf (find-buffer-visiting target)))
             (kill-buffer buf)))))))
+
+;;; Rewrite end-to-end
+
+(ert-deftest ast-grep-test-end-to-end-collect-rewrites ()
+  "Collect rewrites against the JS fixture and verify shape."
+  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (let ((matches (ast-grep--collect-rewrites
+                  "console.log($A)"
+                  "logger.info($A)"
+                  ast-grep-test--fixtures-dir)))
+    (should (= 3 (length matches)))
+    (dolist (m matches)
+      (should (stringp (plist-get m :file)))
+      (should (integerp (plist-get m :start-line)))
+      (should (integerp (plist-get m :end-column)))
+      (should (string-match-p "\\`logger\\.info"
+                              (plist-get m :replacement))))))
+
+(ert-deftest ast-grep-test-end-to-end-rewrite-applies-yes-to-all ()
+  "Driving the prompt with `!' rewrites every match in the fixture."
+  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
+         (tmp-file (expand-file-name "sample.js" tmp-dir))
+         buf)
+    (unwind-protect
+        (progn
+          (copy-file ast-grep-test--sample-file tmp-file)
+          (cl-letf (((symbol-function 'read-string)
+                     (lambda (prompt &rest _)
+                       (cond
+                        ((string-prefix-p "ast-grep pattern" prompt)
+                         "console.log($A)")
+                        ((string-prefix-p "Rewrite" prompt)
+                         "logger.info($A)"))))
+                    ((symbol-function 'read-char-choice)
+                     (lambda (&rest _) ?!))
+                    ((symbol-function 'pop-to-buffer)
+                     (lambda (b &rest _) b)))
+            (ast-grep-rewrite tmp-dir))
+          (setq buf (find-buffer-visiting tmp-file))
+          (should buf)
+          (with-current-buffer buf
+            (should (buffer-modified-p))
+            (let ((content (buffer-string)))
+              (should (string-match-p "logger\\.info(\"hello\")" content))
+              (should (string-match-p "logger\\.info(x)" content))
+              (should (string-match-p "logger\\.info(name)" content))
+              (should-not (string-match-p "console\\.log" content)))))
+      (when (and buf (buffer-live-p buf))
+        (with-current-buffer buf (set-buffer-modified-p nil))
+        (kill-buffer buf))
+      (delete-directory tmp-dir t))))
+
+(ert-deftest ast-grep-test-end-to-end-rewrite-quit-skips-remaining ()
+  "Pressing `q' at the first match leaves the file untouched."
+  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
+         (tmp-file (expand-file-name "sample.js" tmp-dir))
+         buf)
+    (unwind-protect
+        (progn
+          (copy-file ast-grep-test--sample-file tmp-file)
+          (cl-letf (((symbol-function 'read-string)
+                     (lambda (prompt &rest _)
+                       (cond
+                        ((string-prefix-p "ast-grep pattern" prompt)
+                         "console.log($A)")
+                        ((string-prefix-p "Rewrite" prompt)
+                         "logger.info($A)"))))
+                    ((symbol-function 'read-char-choice)
+                     (lambda (&rest _) ?q))
+                    ((symbol-function 'pop-to-buffer)
+                     (lambda (b &rest _) b)))
+            (ast-grep-rewrite tmp-dir))
+          (setq buf (find-buffer-visiting tmp-file))
+          (when buf
+            (with-current-buffer buf
+              (should-not (buffer-modified-p))
+              (should (string-match-p "console\\.log(\"hello\")"
+                                      (buffer-string))))))
+      (when (and buf (buffer-live-p buf)) (kill-buffer buf))
+      (delete-directory tmp-dir t))))
 
 (provide 'test-ast-grep)
 

--- a/tests/ast-grep-test.el
+++ b/tests/ast-grep-test.el
@@ -373,7 +373,44 @@ and routes the chosen candidate through `ast-grep--goto-match'."
                               (plist-get m :replacement))))))
 
 (ert-deftest ast-grep-test-end-to-end-rewrite-applies-yes-to-all ()
-  "Driving the prompt with `!' rewrites every match in the fixture."
+  "Driving the prompt with `A' rewrites every match and saves the file."
+  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
+         (tmp-file (expand-file-name "sample.js" tmp-dir))
+         buf)
+    (unwind-protect
+        (progn
+          (copy-file ast-grep-test--sample-file tmp-file)
+          (cl-letf (((symbol-function 'read-string)
+                     (lambda (prompt &rest _)
+                       (cond
+                        ((string-prefix-p "ast-grep pattern" prompt)
+                         "console.log($A)")
+                        ((string-prefix-p "Rewrite" prompt)
+                         "logger.info($A)"))))
+                    ((symbol-function 'read-char-choice)
+                     (lambda (&rest _) ?A))
+                    ((symbol-function 'pop-to-buffer)
+                     (lambda (b &rest _) b)))
+            (ast-grep-rewrite tmp-dir))
+          (setq buf (find-buffer-visiting tmp-file))
+          (should buf)
+          ;; The buffer should be saved (not modified).
+          (with-current-buffer buf
+            (should-not (buffer-modified-p)))
+          ;; And the file on disk should reflect the rewrite.
+          (with-temp-buffer
+            (insert-file-contents tmp-file)
+            (let ((content (buffer-string)))
+              (should (string-match-p "logger\\.info(\"hello\")" content))
+              (should (string-match-p "logger\\.info(x)" content))
+              (should (string-match-p "logger\\.info(name)" content))
+              (should-not (string-match-p "console\\.log" content)))))
+      (when (and buf (buffer-live-p buf)) (kill-buffer buf))
+      (delete-directory tmp-dir t))))
+
+(ert-deftest ast-grep-test-end-to-end-rewrite-bang-is-alias-for-A ()
+  "`!' is accepted as a legacy alias for `A' (apply all)."
   (skip-unless (ast-grep-test--ast-grep-available-p))
   (let* ((tmp-dir (make-temp-file "ast-grep-rewrite-" t))
          (tmp-file (expand-file-name "sample.js" tmp-dir))
@@ -394,17 +431,10 @@ and routes the chosen candidate through `ast-grep--goto-match'."
                      (lambda (b &rest _) b)))
             (ast-grep-rewrite tmp-dir))
           (setq buf (find-buffer-visiting tmp-file))
-          (should buf)
-          (with-current-buffer buf
-            (should (buffer-modified-p))
-            (let ((content (buffer-string)))
-              (should (string-match-p "logger\\.info(\"hello\")" content))
-              (should (string-match-p "logger\\.info(x)" content))
-              (should (string-match-p "logger\\.info(name)" content))
-              (should-not (string-match-p "console\\.log" content)))))
-      (when (and buf (buffer-live-p buf))
-        (with-current-buffer buf (set-buffer-modified-p nil))
-        (kill-buffer buf))
+          (with-temp-buffer
+            (insert-file-contents tmp-file)
+            (should-not (string-match-p "console\\.log" (buffer-string)))))
+      (when (and buf (buffer-live-p buf)) (kill-buffer buf))
       (delete-directory tmp-dir t))))
 
 (ert-deftest ast-grep-test-end-to-end-rewrite-quit-skips-remaining ()


### PR DESCRIPTION
## Summary
- New `ast-grep-rewrite` and `ast-grep-rewrite-project` commands walk each match with a y/n/!/q prompt, mirroring `project-query-replace-regexp`. Modified buffers are left for the user to save.
- Uses `forward-char` (character index) rather than `move-to-column` (visual column) to compute match regions, so files with tabs or double-width characters get the correct delete-region bounds.
- Reuses ast-grep's `--rewrite` flag plus existing JSON streaming pipeline; matches are grouped by file and applied in reverse position order so earlier edits don't invalidate later offsets.

Closes #3. Supersedes the bulk-replace approach in the (closed) #7.

https://github.com/user-attachments/assets/79205a27-a877-4d95-a501-2dbdcaf6ca39

## UX
```
M-x ast-grep-rewrite
  ast-grep pattern: console.log($A)
  Rewrite `console.log($A)' with: logger.info($A)
  Replace `console.log("hello")' with `logger.info("hello")'? (y/n/!/q)
```
- `y` apply this match
- `n` skip
- `!` apply this and all remaining
- `q` quit
