### PR TITLE
Add optional nerd-icons file icons to search candidates

### DIFF
--- a/ast-grep-core.el
+++ b/ast-grep-core.el
@@ -39,6 +39,12 @@ the command being executed, working directory, and raw output."
   :type 'integer
   :group 'ast-grep)
 
+(defcustom ast-grep-use-nerd-icons t
+  "When non-nil, prefix search candidates with nerd-icons file icons.
+Requires the optional nerd-icons package."
+  :type 'boolean
+  :group 'ast-grep)
+
 (defvar ast-grep-history nil
   "History list for ast-grep searches.")
 
@@ -155,19 +161,39 @@ that includes both stdout and stderr when available."
   (string-trim
    (replace-regexp-in-string "[\r\n]+" " " (or text ""))))
 
+(defun ast-grep--nerd-icons-available-p ()
+  "Return non-nil when nerd-icons file icons can be rendered."
+  (and ast-grep-use-nerd-icons
+       (require 'nerd-icons nil t)
+       (fboundp 'nerd-icons-icon-for-file)))
+
+(declare-function nerd-icons-icon-for-file "nerd-icons")
+
+(defun ast-grep--candidate-icon-display (display file)
+  "Return DISPLAY with an optional nerd-icons prefix for FILE.
+The underlying candidate string stays DISPLAY so candidate lookup and
+legacy parsing keep working; only the rendered form gains an icon."
+  (if (ast-grep--nerd-icons-available-p)
+      (propertize display
+                  'display
+                  (concat (nerd-icons-icon-for-file file) " " display))
+    display))
+
 (defun ast-grep--format-candidate (match)
   "Return a display candidate for MATCH and register its structured data."
-  (let* ((text (ast-grep--candidate-display-text (plist-get match :text)))
+  (let* ((file (plist-get match :file))
+         (text (ast-grep--candidate-display-text (plist-get match :text)))
          (display (format "%s:%d:%d:%s"
-                          (plist-get match :file)
+                          file
                           (1+ (plist-get match :start-line))
                           (plist-get match :start-column)
-                          text)))
+                          text))
+         (candidate (ast-grep--candidate-icon-display display file)))
     (puthash display match ast-grep--candidate-table)
     (add-text-properties 0 (length display)
                          (list ast-grep--match-property match)
-                         display)
-    display))
+                         candidate)
+    candidate))
 
 (defun ast-grep--legacy-candidate-match (candidate)
   "Parse legacy string CANDIDATE into a match plist."

--- a/ast-grep-core.el
+++ b/ast-grep-core.el
@@ -161,23 +161,41 @@ that includes both stdout and stderr when available."
   (string-trim
    (replace-regexp-in-string "[\r\n]+" " " (or text ""))))
 
+(defvar ast-grep--nerd-icons-available-cache nil
+  "Cached pair of (`ast-grep-use-nerd-icons' . availability), or nil if unprobed.")
+
 (defun ast-grep--nerd-icons-available-p ()
-  "Return non-nil when nerd-icons file icons can be rendered."
-  (and ast-grep-use-nerd-icons
-       (require 'nerd-icons nil t)
-       (fboundp 'nerd-icons-icon-for-file)))
+  "Return non-nil when nerd-icons file icons can be rendered.
+The optional nerd-icons package is probed at most once per
+`ast-grep-use-nerd-icons' setting."
+  (unless (eq (car ast-grep--nerd-icons-available-cache)
+              ast-grep-use-nerd-icons)
+    (setq ast-grep--nerd-icons-available-cache
+          (cons ast-grep-use-nerd-icons
+                (and ast-grep-use-nerd-icons
+                     (require 'nerd-icons nil t)
+                     (fboundp 'nerd-icons-icon-for-file)))))
+  (cdr ast-grep--nerd-icons-available-cache))
 
 (declare-function nerd-icons-icon-for-file "nerd-icons")
 
 (defun ast-grep--candidate-icon-display (display file)
   "Return DISPLAY with an optional nerd-icons prefix for FILE.
-The underlying candidate string stays DISPLAY so candidate lookup and
-legacy parsing keep working; only the rendered form gains an icon."
+Only the icon placeholder uses a `display' property so ivy/consult can
+still decorate the candidate text with match faces."
   (if (ast-grep--nerd-icons-available-p)
-      (propertize display
-                  'display
-                  (concat (nerd-icons-icon-for-file file) " " display))
+      (concat (propertize " "
+                          'display (concat (nerd-icons-icon-for-file file) " ")
+                          'rear-nonsticky t)
+              display)
     display))
+
+(defun ast-grep--candidate-lookup-key (candidate)
+  "Return the hash-table lookup key for plain-text CANDIDATE."
+  (if (and (not (zerop (length candidate)))
+           (eq (aref candidate 0) ?\s))
+      (substring candidate 1)
+    candidate))
 
 (defun ast-grep--format-candidate (match)
   "Return a display candidate for MATCH and register its structured data."
@@ -190,7 +208,7 @@ legacy parsing keep working; only the rendered form gains an icon."
                           text))
          (candidate (ast-grep--candidate-icon-display display file)))
     (puthash display match ast-grep--candidate-table)
-    (add-text-properties 0 (length display)
+    (add-text-properties 0 (length candidate)
                          (list ast-grep--match-property match)
                          candidate)
     candidate))
@@ -213,9 +231,14 @@ that candidates survive backends that strip text properties."
    ((and (consp candidate) (plist-get candidate :file))
     candidate)
    ((stringp candidate)
-    (or (get-text-property 0 ast-grep--match-property candidate)
-        (gethash (substring-no-properties candidate) ast-grep--candidate-table)
-        (ast-grep--legacy-candidate-match candidate)))))
+    (let ((plain (substring-no-properties candidate)))
+      (or (get-text-property 0 ast-grep--match-property candidate)
+          (gethash plain ast-grep--candidate-table)
+          (gethash (ast-grep--candidate-lookup-key plain)
+                   ast-grep--candidate-table)
+          (ast-grep--legacy-candidate-match plain)
+          (ast-grep--legacy-candidate-match
+           (ast-grep--candidate-lookup-key plain)))))))
 
 (defun ast-grep--goto-line-column (line column)
   "Move point to 0-based LINE and character-index COLUMN.

--- a/ast-grep-ivy.el
+++ b/ast-grep-ivy.el
@@ -85,7 +85,8 @@ When GENERATION is non-nil, output from stale processes is ignored."
       (when lines
         (counsel--async-filter
          process
-         (concat (mapconcat #'substring-no-properties lines "\n") "\n"))))))
+         ;; Keep text properties so nerd-icons `display' prefixes survive.
+         (concat (mapconcat #'identity lines "\n") "\n"))))))
 
 (defun ast-grep--ivy-collection (directory)
   "Return a dynamic ivy collection function scoped to DIRECTORY."

--- a/tests/ast-grep-core-test.el
+++ b/tests/ast-grep-core-test.el
@@ -51,32 +51,36 @@
 
 (ert-deftest ast-grep-core-test-format-candidate-keeps-display-single-line ()
   "Multiline match text must not break backend newline protocols."
-  (let* ((line "{\"file\":\"a.js\",\"range\":{\"start\":{\"line\":0,\"column\":0}},\"text\":\"foo\\nbar\"}")
-         (candidate (ast-grep--parse-stream-line line))
-         (match (ast-grep--candidate-match candidate)))
-    (should (equal candidate "a.js:1:0:foo bar"))
-    (should-not (string-match-p "\n" candidate))
-    (should (equal (plist-get match :text) "foo\nbar"))
-    (should (eq (ast-grep--candidate-match
-                 (substring-no-properties candidate))
-                match))))
+  (let ((ast-grep-use-nerd-icons nil))
+    (setq ast-grep--nerd-icons-available-cache nil)
+    (let* ((line "{\"file\":\"a.js\",\"range\":{\"start\":{\"line\":0,\"column\":0}},\"text\":\"foo\\nbar\"}")
+           (candidate (ast-grep--parse-stream-line line))
+           (match (ast-grep--candidate-match candidate)))
+      (should (equal candidate "a.js:1:0:foo bar"))
+      (should-not (string-match-p "\n" candidate))
+      (should (equal (plist-get match :text) "foo\nbar"))
+      (should (eq (ast-grep--candidate-match
+                   (substring-no-properties candidate))
+                  match)))))
 
 (ert-deftest ast-grep-core-test-format-candidate-keeps-structured-match ()
   "Display text is not the data contract; the match plist is."
-  (let* ((match (list :file "C:/tmp/a:b.js"
-                      :start-line 4
-                      :start-column 2
-                      :text "x:y"))
-         (candidate (ast-grep--format-candidate match)))
-    (should (equal candidate "C:/tmp/a:b.js:5:2:x:y"))
-    (should (eq (ast-grep--candidate-match candidate) match))
-    ;; Simulate backends that strip text properties.
-    (should (eq (ast-grep--candidate-match
-                 (substring-no-properties candidate))
-                match))))
+  (let ((ast-grep-use-nerd-icons nil))
+    (setq ast-grep--nerd-icons-available-cache nil)
+    (let* ((match (list :file "C:/tmp/a:b.js"
+                        :start-line 4
+                        :start-column 2
+                        :text "x:y"))
+           (candidate (ast-grep--format-candidate match)))
+      (should (equal candidate "C:/tmp/a:b.js:5:2:x:y"))
+      (should (eq (ast-grep--candidate-match candidate) match))
+      ;; Simulate backends that strip text properties.
+      (should (eq (ast-grep--candidate-match
+                   (substring-no-properties candidate))
+                  match)))))
 
 (ert-deftest ast-grep-core-test-format-candidate-uses-nerd-icons-display ()
-  "When nerd-icons is available, candidates keep plain text but gain a display icon."
+  "When nerd-icons is available, only the icon placeholder uses `display'."
   (let* ((match (list :file "a.js"
                       :start-line 0
                       :start-column 0
@@ -88,10 +92,34 @@
                  ((symbol-function 'nerd-icons-icon-for-file)
                   (lambda (file) (propertize icon 'face 'nerd-icons-js))))
         (let ((candidate (ast-grep--format-candidate match)))
-          (should (equal candidate display))
+          (should (equal (substring candidate 1) display))
           (should (equal (get-text-property 0 'display candidate)
-                        (concat icon " " display)))
-          (should (eq (ast-grep--candidate-match candidate) match)))))))
+                        (concat icon " ")))
+          (should (null (get-text-property 1 'display candidate)))
+          (should (eq (ast-grep--candidate-match candidate) match))
+          (should (eq (ast-grep--candidate-match
+                       (substring-no-properties candidate))
+                      match)))))))
+
+(ert-deftest ast-grep-core-test-nerd-icons-available-probed-once ()
+  "Nerd-icons availability is probed at most once per `ast-grep-use-nerd-icons' value."
+  (let ((require-count 0)
+        (ast-grep-use-nerd-icons t))
+    (setq ast-grep--nerd-icons-available-cache nil)
+    (cl-letf (((symbol-function 'require)
+               (lambda (feature &optional _noerror _record)
+                 (when (eq feature 'nerd-icons)
+                   (cl-incf require-count))
+                 nil)))
+      (should-not (ast-grep--nerd-icons-available-p))
+      (should-not (ast-grep--nerd-icons-available-p))
+      (should (= require-count 1))
+      (setq ast-grep-use-nerd-icons nil)
+      (should-not (ast-grep--nerd-icons-available-p))
+      (should (= require-count 1))
+      (setq ast-grep-use-nerd-icons t)
+      (should-not (ast-grep--nerd-icons-available-p))
+      (should (= require-count 2)))))
 
 (ert-deftest ast-grep-core-test-parse-stream-output ()
   "Test parsing of multi-line streaming output, skipping malformed lines."

--- a/tests/ast-grep-core-test.el
+++ b/tests/ast-grep-core-test.el
@@ -75,6 +75,24 @@
                  (substring-no-properties candidate))
                 match))))
 
+(ert-deftest ast-grep-core-test-format-candidate-uses-nerd-icons-display ()
+  "When nerd-icons is available, candidates keep plain text but gain a display icon."
+  (let* ((match (list :file "a.js"
+                      :start-line 0
+                      :start-column 0
+                      :text "hit"))
+         (display "a.js:1:0:hit")
+         (icon "js-icon"))
+    (let ((ast-grep-use-nerd-icons t))
+      (cl-letf (((symbol-function 'ast-grep--nerd-icons-available-p) (lambda () t))
+                 ((symbol-function 'nerd-icons-icon-for-file)
+                  (lambda (file) (propertize icon 'face 'nerd-icons-js))))
+        (let ((candidate (ast-grep--format-candidate match)))
+          (should (equal candidate display))
+          (should (equal (get-text-property 0 'display candidate)
+                        (concat icon " " display)))
+          (should (eq (ast-grep--candidate-match candidate) match)))))))
+
 (ert-deftest ast-grep-core-test-parse-stream-output ()
   "Test parsing of multi-line streaming output, skipping malformed lines."
   (let ((output (concat "{\"file\":\"a.js\",\"range\":{\"start\":{\"line\":0,\"column\":0}},\"text\":\"x\"}\n"


### PR DESCRIPTION
Prefix completion candidates with file-type icons when nerd-icons is available, while keeping plain-text candidates for lookup and legacy parsing. Preserve text properties in ivy async output so display prefixes survive filtering.