### PR TITLE
fix(icons): render nerd-icons at display layer to keep prefix completion

### DIFF
--- a/ast-grep-consult.el
+++ b/ast-grep-consult.el
@@ -74,6 +74,10 @@ in as you type; type after `#' to narrow with `completing-read'."
                  :prompt "ast-grep: "
                  :lookup #'consult--lookup-member
                  :state (ast-grep--state)
+                 :annotate (lambda (cand)
+                             (list cand
+                                   (ast-grep--candidate-icon-prefix cand)
+                                   ""))
                  :category 'ast-grep
                  :history 'ast-grep-history
                  :require-match t)))

--- a/ast-grep-core.el
+++ b/ast-grep-core.el
@@ -179,39 +179,44 @@ The optional nerd-icons package is probed at most once per
 
 (declare-function nerd-icons-icon-for-file "nerd-icons")
 
-(defun ast-grep--candidate-icon-display (display file)
-  "Return DISPLAY with an optional nerd-icons prefix for FILE.
-Only the icon placeholder uses a `display' property so ivy/consult can
-still decorate the candidate text with match faces."
-  (if (ast-grep--nerd-icons-available-p)
-      (concat (propertize " "
-                          'display (concat (nerd-icons-icon-for-file file) " ")
-                          'rear-nonsticky t)
-              display)
-    display))
+(defun ast-grep--candidate-icon-prefix (candidate)
+  "Return a nerd-icons display prefix for CANDIDATE, or an empty string.
+The prefix is rendered by the completion UI (an affixation function or
+an ivy display transformer), so it never becomes part of the candidate
+string.  Keeping the candidate body untouched preserves prefix-style
+completion filtering and the match-face highlighting backends add."
+  (if-let* (((ast-grep--nerd-icons-available-p))
+            (match (ast-grep--candidate-match candidate))
+            (file (plist-get match :file)))
+      (concat (nerd-icons-icon-for-file file) " ")
+    ""))
 
-(defun ast-grep--candidate-lookup-key (candidate)
-  "Return the hash-table lookup key for plain-text CANDIDATE."
-  (if (and (not (zerop (length candidate)))
-           (eq (aref candidate 0) ?\s))
-      (substring candidate 1)
-    candidate))
+(defun ast-grep--affixation (candidates)
+  "Affixation function prefixing each of CANDIDATES with its file icon."
+  (mapcar (lambda (candidate)
+            (list candidate (ast-grep--candidate-icon-prefix candidate) ""))
+          candidates))
+
+(defun ast-grep--completion-table (candidates)
+  "Return a completion table over CANDIDATES that adds nerd-icons affixes."
+  (lambda (string predicate action)
+    (if (eq action 'metadata)
+        '(metadata (affixation-function . ast-grep--affixation))
+      (complete-with-action action candidates string predicate))))
 
 (defun ast-grep--format-candidate (match)
   "Return a display candidate for MATCH and register its structured data."
-  (let* ((file (plist-get match :file))
-         (text (ast-grep--candidate-display-text (plist-get match :text)))
+  (let* ((text (ast-grep--candidate-display-text (plist-get match :text)))
          (display (format "%s:%d:%d:%s"
-                          file
+                          (plist-get match :file)
                           (1+ (plist-get match :start-line))
                           (plist-get match :start-column)
-                          text))
-         (candidate (ast-grep--candidate-icon-display display file)))
+                          text)))
     (puthash display match ast-grep--candidate-table)
-    (add-text-properties 0 (length candidate)
+    (add-text-properties 0 (length display)
                          (list ast-grep--match-property match)
-                         candidate)
-    candidate))
+                         display)
+    display))
 
 (defun ast-grep--legacy-candidate-match (candidate)
   "Parse legacy string CANDIDATE into a match plist."
@@ -231,14 +236,9 @@ that candidates survive backends that strip text properties."
    ((and (consp candidate) (plist-get candidate :file))
     candidate)
    ((stringp candidate)
-    (let ((plain (substring-no-properties candidate)))
-      (or (get-text-property 0 ast-grep--match-property candidate)
-          (gethash plain ast-grep--candidate-table)
-          (gethash (ast-grep--candidate-lookup-key plain)
-                   ast-grep--candidate-table)
-          (ast-grep--legacy-candidate-match plain)
-          (ast-grep--legacy-candidate-match
-           (ast-grep--candidate-lookup-key plain)))))))
+    (or (get-text-property 0 ast-grep--match-property candidate)
+        (gethash (substring-no-properties candidate) ast-grep--candidate-table)
+        (ast-grep--legacy-candidate-match candidate)))))
 
 (defun ast-grep--goto-line-column (line column)
   "Move point to 0-based LINE and character-index COLUMN.

--- a/ast-grep-ivy.el
+++ b/ast-grep-ivy.el
@@ -18,6 +18,7 @@
 (require 'ast-grep-core)
 
 (declare-function ivy-read "ivy")
+(declare-function ivy-set-display-transformer "ivy")
 (declare-function counsel--async-command "counsel")
 (declare-function counsel--async-filter "counsel")
 (declare-function counsel-delete-process "counsel")
@@ -85,8 +86,7 @@ When GENERATION is non-nil, output from stale processes is ignored."
       (when lines
         (counsel--async-filter
          process
-         ;; Keep text properties so nerd-icons `display' prefixes survive.
-         (concat (mapconcat #'identity lines "\n") "\n"))))))
+         (concat (mapconcat #'substring-no-properties lines "\n") "\n"))))))
 
 (defun ast-grep--ivy-collection (directory)
   "Return a dynamic ivy collection function scoped to DIRECTORY."
@@ -113,6 +113,12 @@ When GENERATION is non-nil, output from stale processes is ignored."
     (ast-grep--goto-match candidate)
     (pulse-momentary-highlight-one-line (point))))
 
+(defun ast-grep--ivy-display-transformer (candidate)
+  "Prefix CANDIDATE with its nerd-icons file icon for ivy display only.
+The underlying CANDIDATE string is left untouched, so ivy's own
+matching and the candidate action keep operating on the plain text."
+  (concat (ast-grep--candidate-icon-prefix candidate) candidate))
+
 (defun ast-grep--search-ivy (directory)
   "Search asynchronously using counsel/ivy in DIRECTORY.
 The ivy backend is isolated from consult because ivy owns minibuffer
@@ -122,6 +128,8 @@ counsel.  Candidate actions first recover data from that registry, then
 fall back to the shared legacy display-string parser when registry
 context is unavailable."
   (ast-grep--reset-candidate-table)
+  (ivy-set-display-transformer 'ast-grep-search
+                               #'ast-grep--ivy-display-transformer)
   (ivy-read "ast-grep: "
             (ast-grep--ivy-collection directory)
             :dynamic-collection t

--- a/ast-grep-sync.el
+++ b/ast-grep-sync.el
@@ -25,7 +25,8 @@
         (when-let ((selection
                     (completing-read
                      (format "ast-grep [%s]: " pattern)
-                     candidates nil t nil 'ast-grep-history)))
+                     (ast-grep--completion-table candidates)
+                     nil t nil 'ast-grep-history)))
           (ast-grep--goto-match selection))
       (progn
         (message "No matches found for pattern: %s" pattern)

--- a/tests/ast-grep-core-test.el
+++ b/tests/ast-grep-core-test.el
@@ -79,8 +79,8 @@
                    (substring-no-properties candidate))
                   match)))))
 
-(ert-deftest ast-grep-core-test-format-candidate-uses-nerd-icons-display ()
-  "When nerd-icons is available, only the icon placeholder uses `display'."
+(ert-deftest ast-grep-core-test-format-candidate-keeps-clean-body-with-icons ()
+  "The candidate body stays icon-free; the icon is offered via affixation."
   (let* ((match (list :file "a.js"
                       :start-line 0
                       :start-column 0
@@ -90,16 +90,38 @@
     (let ((ast-grep-use-nerd-icons t))
       (cl-letf (((symbol-function 'ast-grep--nerd-icons-available-p) (lambda () t))
                  ((symbol-function 'nerd-icons-icon-for-file)
-                  (lambda (file) (propertize icon 'face 'nerd-icons-js))))
+                  (lambda (_file) (propertize icon 'face 'nerd-icons-js))))
         (let ((candidate (ast-grep--format-candidate match)))
-          (should (equal (substring candidate 1) display))
-          (should (equal (get-text-property 0 'display candidate)
-                        (concat icon " ")))
-          (should (null (get-text-property 1 'display candidate)))
+          ;; Body is the plain display string: no leading space, no `display'.
+          (should (equal candidate display))
+          (should (null (get-text-property 0 'display candidate)))
+          ;; The icon is exposed through the prefix helper / affixation instead.
+          (should (equal (ast-grep--candidate-icon-prefix candidate)
+                         (concat icon " ")))
+          (should (equal (ast-grep--affixation (list candidate))
+                         (list (list candidate (concat icon " ") ""))))
           (should (eq (ast-grep--candidate-match candidate) match))
           (should (eq (ast-grep--candidate-match
                        (substring-no-properties candidate))
                       match)))))))
+
+(ert-deftest ast-grep-core-test-candidate-body-supports-prefix-completion ()
+  "Enabling icons must not break basic (prefix) completion of candidates."
+  (let ((ast-grep-use-nerd-icons t))
+    (cl-letf (((symbol-function 'ast-grep--nerd-icons-available-p) (lambda () t))
+              ((symbol-function 'nerd-icons-icon-for-file) (lambda (_file) "I")))
+      (ast-grep--reset-candidate-table)
+      (let* ((c1 (ast-grep--format-candidate
+                  (list :file "a.js" :start-line 0 :start-column 0 :text "hit")))
+             (c2 (ast-grep--format-candidate
+                  (list :file "b.js" :start-line 0 :start-column 0 :text "x")))
+             (completion-styles '(basic))
+             (res (completion-all-completions "a" (list c1 c2) nil 1)))
+        (when (and res (integerp (cdr (last res)))) (setcdr (last res) nil))
+        ;; "a" prefix-matches the a.js candidate; the leading-space bug would
+        ;; have returned nil here.
+        (should (member "a.js:1:0:hit" (mapcar #'substring-no-properties res)))
+        (should-not (member "b.js:1:0:x" (mapcar #'substring-no-properties res)))))))
 
 (ert-deftest ast-grep-core-test-nerd-icons-available-probed-once ()
   "Nerd-icons availability is probed at most once per `ast-grep-use-nerd-icons' value."


### PR DESCRIPTION
Icons are added at the completion display layer (affixation function / ivy display transformer) instead of inside the candidate string, so prefix-style completion filtering and match highlighting keep working.