### PR TITLE
feat(helm): helm search backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
           - emacs-version: "28.2"
             backend: ivy
             eask-script: test:ivy
+          - emacs-version: "28.2"
+            backend: helm
+            eask-script: test:helm
           # Consult currently requires Emacs 29.1+, so consult/full jobs
           # intentionally start at 29.4.
           - emacs-version: "29.4"
@@ -32,6 +35,9 @@ jobs:
             backend: ivy
             eask-script: test:ivy
           - emacs-version: "29.4"
+            backend: helm
+            eask-script: test:helm
+          - emacs-version: "29.4"
             backend: full
             eask-script: test:full
           - emacs-version: "30.1"
@@ -43,6 +49,9 @@ jobs:
           - emacs-version: "30.1"
             backend: ivy
             eask-script: test:ivy
+          - emacs-version: "30.1"
+            backend: helm
+            eask-script: test:helm
           - emacs-version: "30.1"
             backend: full
             eask-script: test:full

--- a/Eask
+++ b/Eask
@@ -15,7 +15,7 @@
 (files "ast-grep*.el")
 
 (script "compile"
-        "eask --strict compile ast-grep-core.el ast-grep-sync.el ast-grep-consult.el ast-grep-ivy.el ast-grep.el")
+        "eask --strict compile ast-grep-core.el ast-grep-sync.el ast-grep-consult.el ast-grep-ivy.el ast-grep-helm.el ast-grep.el")
 
 (script "test"
         "eask emacs -batch -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")
@@ -29,5 +29,8 @@
 (script "test:ivy"
         "eask clean workspace && eask install ivy counsel && eask emacs -batch --eval '(setenv \"AST_GREP_TEST_BACKEND\" \"ivy\")' -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")
 
+(script "test:helm"
+        "eask clean workspace && eask install helm && eask emacs -batch --eval '(setenv \"AST_GREP_TEST_BACKEND\" \"helm\")' -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")
+
 (script "test:full"
-        "eask clean workspace && eask install compat consult ivy counsel && eask emacs -batch --eval '(setenv \"AST_GREP_TEST_BACKEND\" \"full\")' -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")
+        "eask clean workspace && eask install compat consult ivy counsel helm && eask emacs -batch --eval '(setenv \"AST_GREP_TEST_BACKEND\" \"full\")' -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")

--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@ An Emacs interface to [[https://github.com/ast-grep/ast-grep][ast-grep]], a CLI 
 - Project-wide search support
 - Integration with completing-read frameworks (Vertico, etc.)
 - Streaming JSON parsing for efficient processing
-- Async search with live results via consult, or via counsel/ivy when ~ivy-mode~ is active
+- Async search with live results via consult, Helm, or counsel/ivy when ~ivy-mode~ is active
 - Interactive rewrite across files (~project-query-replace-regexp~ style)
 
 ** Requirements
@@ -25,16 +25,18 @@ An Emacs interface to [[https://github.com/ast-grep/ast-grep][ast-grep]], a CLI 
 - [[https://github.com/ast-grep/ast-grep][ast-grep]] CLI tool installed and available in PATH
 - Optional, for live async search:
   - [[https://github.com/minad/consult][consult]] (pairs with Vertico, Selectrum, etc.), or
+  - [[https://emacs-helm.github.io/helm/][Helm]] when ~helm-mode~ is active, or
   - [[https://github.com/abo-abo/swiper][ivy + counsel]] when ~ivy-mode~ is active
 
 *** Async Backend Support
 
 | Backend selector | Emacs version | Runtime dependency | Selection behavior | Eask sandbox |
 |------------------+---------------+--------------------+--------------------+--------------|
-| ~auto~           | 28.1+, consult path requires 29.1+ | Optional consult or ivy/counsel | Uses ivy/counsel when ~ivy-mode~ is active and available; otherwise consult when available; otherwise sync | ~eask run script test:full~ |
+| ~auto~           | 28.1+, consult path requires 29.1+ | Optional consult, Helm, or ivy/counsel | Uses ivy/counsel when ~ivy-mode~ is active and available; otherwise Helm when ~helm-mode~ is active and available; otherwise consult when available; otherwise sync | ~eask run script test:full~ |
 | ~sync~           | 28.1+ | None | Uses synchronous ~completing-read~ candidates | ~eask run script test:sync~ |
 | ~consult~        | 29.1+ | consult (and its dependencies) | Uses consult async search, falling back to sync if consult is unavailable | ~eask run script test:consult~ |
 | ~ivy~            | 28.1+ | ivy + counsel | Uses counsel/ivy async search, falling back to sync if ivy/counsel is unavailable | ~eask run script test:ivy~ |
+| ~helm~           | 28.1+ | Helm | Uses Helm async search, falling back to sync if Helm is unavailable | ~eask run script test:helm~ |
 
 ** Installation
 
@@ -99,18 +101,19 @@ Customize the following variables:
 - ~ast-grep-executable~ - Path to ast-grep executable (default: "ast-grep")
 - ~ast-grep-debug~ - Enable debug output for troubleshooting (default: nil)
 - ~ast-grep-async-min-input~ - Minimum input length before triggering async search (default: 3)
-- ~ast-grep-search-backend~ - Backend for ~ast-grep-search~ (default: ~auto~; accepts ~consult~, ~ivy~, or ~sync~). In ~auto~, active ~ivy-mode~ uses counsel/ivy when available, otherwise consult is used when available, with synchronous ~completing-read~ as the fallback.
+- ~ast-grep-search-backend~ - Backend for ~ast-grep-search~ (default: ~auto~; accepts ~consult~, ~ivy~, ~helm~, or ~sync~). In ~auto~, active ~ivy-mode~ uses counsel/ivy when available, active ~helm-mode~ uses Helm when available, otherwise consult is used when available, with synchronous ~completing-read~ as the fallback.
 
 ** Development
 
 This repository uses Eask to keep optional async backends isolated during
-tests. The sync sandbox has no optional completion dependency; consult
-and ivy sandboxes install only the backend they exercise.
+tests. The sync sandbox has no optional completion dependency; consult,
+ivy, and Helm sandboxes install only the backend they exercise.
 
 #+begin_src bash
 eask run script compile
 eask run script test:sync
 eask run script test:consult
 eask run script test:ivy
+eask run script test:helm
 eask run script test:full
 #+end_src

--- a/ast-grep-consult.el
+++ b/ast-grep-consult.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Keywords: tools, matching
 
 ;; This file is not part of GNU Emacs.

--- a/ast-grep-core.el
+++ b/ast-grep-core.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Keywords: tools, matching
 
 ;; This file is not part of GNU Emacs.

--- a/ast-grep-helm.el
+++ b/ast-grep-helm.el
@@ -37,8 +37,12 @@
        (fboundp 'helm-make-source)))
 
 (defun ast-grep--helm-command (input directory)
-  "Build ast-grep command for INPUT in DIRECTORY, or nil if INPUT is too short."
-  (when (and input (>= (length input) ast-grep-async-min-input))
+  "Build ast-grep command for INPUT in DIRECTORY, or nil if INPUT is too short.
+INPUT is measured with `string-width', not `length', because Helm gates
+`:requires-pattern' by width; the two checks must agree or a wide-char
+\(e.g. CJK) pattern passes Helm's gate, reaches
+`ast-grep--helm-candidates-process', and errors instead of searching."
+  (when (and input (>= (string-width input) ast-grep-async-min-input))
     (ast-grep--build-command input directory)))
 
 (defun ast-grep--helm-candidates-process (directory)

--- a/ast-grep-helm.el
+++ b/ast-grep-helm.el
@@ -1,0 +1,96 @@
+;;; ast-grep-helm.el --- Helm backend for ast-grep.el -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 SunskyXH
+
+;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Keywords: tools, matching
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Helm async backend for ast-grep.el.  This file intentionally does
+;; not require helm at load time; availability is checked when the
+;; backend is selected.
+
+;;; Code:
+
+(require 'ast-grep-core)
+
+(declare-function helm "helm")
+(declare-function helm-make-source "helm-source")
+(declare-function pulse-momentary-highlight-one-line "pulse")
+
+(defvar helm-pattern)
+
+(defun ast-grep--helm-ensure-function (function)
+  "Ensure Helm FUNCTION is defined, loading Helm if needed."
+  (unless (fboundp function)
+    (require 'helm))
+  (unless (fboundp function)
+    (error "Helm function `%s' is not available" function)))
+
+(defun ast-grep--helm-available-p ()
+  "Return non-nil when helm is loadable."
+  (and (require 'helm nil t)
+       (fboundp 'helm)
+       (fboundp 'helm-make-source)))
+
+(defun ast-grep--helm-command (input directory)
+  "Build ast-grep command for INPUT in DIRECTORY, or nil if INPUT is too short."
+  (when (and input (>= (length input) ast-grep-async-min-input))
+    (ast-grep--build-command input directory)))
+
+(defun ast-grep--helm-candidates-process (directory)
+  "Start an ast-grep process for the current `helm-pattern' in DIRECTORY."
+  (let ((command (ast-grep--helm-command helm-pattern directory)))
+    (unless command
+      (error "Helm pattern is shorter than `ast-grep-async-min-input'"))
+    (ast-grep--reset-candidate-table)
+    (apply #'start-process "ast-grep-helm" nil command)))
+
+(defun ast-grep--helm-display-candidate (candidate)
+  "Return a Helm display/real pair for CANDIDATE."
+  (cons (concat (ast-grep--candidate-icon-prefix candidate) candidate)
+        candidate))
+
+(defun ast-grep--helm-filter-one-by-one (line)
+  "Parse one JSON LINE from Helm async output into a display candidate."
+  (when-let ((candidate (ast-grep--parse-stream-line line)))
+    (ast-grep--helm-display-candidate candidate)))
+
+(defun ast-grep--helm-action (candidate)
+  "Preview or visit CANDIDATE for the Helm backend."
+  (when (ast-grep--candidate-match candidate)
+    (ast-grep--goto-match candidate)
+    (pulse-momentary-highlight-one-line (point))))
+
+(defun ast-grep--helm-source (directory)
+  "Create a Helm async source for DIRECTORY."
+  (ast-grep--helm-ensure-function 'helm-make-source)
+  (helm-make-source
+   "ast-grep" 'helm-source-async
+   :candidates-process (lambda ()
+                         (ast-grep--helm-candidates-process directory))
+   :filter-one-by-one #'ast-grep--helm-filter-one-by-one
+   :action #'ast-grep--helm-action
+   :persistent-action #'ast-grep--helm-action
+   :persistent-help "Preview match"
+   :requires-pattern ast-grep-async-min-input
+   :nohighlight t
+   :nomark t))
+
+(defun ast-grep--search-helm (directory)
+  "Search asynchronously using Helm in DIRECTORY.
+The ast-grep pattern is typed in the Helm minibuffer.  Results stream
+in as you type after `ast-grep-async-min-input' characters."
+  (ast-grep--helm-ensure-function 'helm)
+  (ast-grep--reset-candidate-table)
+  (helm :sources (ast-grep--helm-source directory)
+        :prompt "ast-grep: "
+        :buffer "*helm ast-grep*"
+        :history 'ast-grep-history))
+
+(provide 'ast-grep-helm)
+
+;;; ast-grep-helm.el ends here

--- a/ast-grep-helm.el
+++ b/ast-grep-helm.el
@@ -66,13 +66,40 @@ INPUT is measured with `string-width', not `length', because Helm gates
     (ast-grep--helm-display-candidate candidate)))
 
 (defun ast-grep--helm-action (candidate)
-  "Preview or visit CANDIDATE for the Helm backend."
+  "Visit CANDIDATE for the Helm backend."
   (when (ast-grep--candidate-match candidate)
     (ast-grep--goto-match candidate)
     (pulse-momentary-highlight-one-line (point))))
 
+(defvar ast-grep--helm-preview-buffers nil
+  "Buffers opened only to preview candidates in the current Helm session.")
+
+(defun ast-grep--helm-preview (candidate)
+  "Preview CANDIDATE for the Helm backend.
+A buffer this opens is recorded in `ast-grep--helm-preview-buffers' so
+`ast-grep--helm-cleanup' can kill it when the session ends; buffers
+that were already live are left alone.  Selecting a candidate goes
+through `ast-grep--helm-action' instead, which visits for good."
+  (when-let* ((match (ast-grep--candidate-match candidate))
+              (file (plist-get match :file)))
+    (unless (find-buffer-visiting file)
+      (push (find-file-noselect file) ast-grep--helm-preview-buffers))
+    (ast-grep--goto-match candidate)
+    (pulse-momentary-highlight-one-line (point))))
+
+(defun ast-grep--helm-cleanup ()
+  "Kill unmodified buffers opened only for preview during the Helm session."
+  (dolist (buffer ast-grep--helm-preview-buffers)
+    (when (and (buffer-live-p buffer)
+               (not (buffer-modified-p buffer)))
+      (kill-buffer buffer)))
+  (setq ast-grep--helm-preview-buffers nil))
+
 (defun ast-grep--helm-source (directory)
-  "Create a Helm async source for DIRECTORY."
+  "Create a Helm async source for DIRECTORY.
+The source enables `helm-follow-mode' (`:follow' 1), so moving between
+candidates previews them live; the cleanup hook kills buffers that were
+opened purely for preview once the session ends."
   (ast-grep--helm-ensure-function 'helm-make-source)
   (helm-make-source
    "ast-grep" 'helm-source-async
@@ -80,8 +107,10 @@ INPUT is measured with `string-width', not `length', because Helm gates
                          (ast-grep--helm-candidates-process directory))
    :filter-one-by-one #'ast-grep--helm-filter-one-by-one
    :action #'ast-grep--helm-action
-   :persistent-action #'ast-grep--helm-action
+   :persistent-action #'ast-grep--helm-preview
    :persistent-help "Preview match"
+   :cleanup #'ast-grep--helm-cleanup
+   :follow 1
    :requires-pattern ast-grep-async-min-input
    :nohighlight t
    :nomark t))
@@ -89,7 +118,10 @@ INPUT is measured with `string-width', not `length', because Helm gates
 (defun ast-grep--search-helm (directory)
   "Search asynchronously using Helm in DIRECTORY.
 The ast-grep pattern is typed in the Helm minibuffer.  Results stream
-in as you type after `ast-grep-async-min-input' characters."
+in as you type after `ast-grep-async-min-input' characters, and the
+selected candidate is previewed live (helm-follow-mode; toggle with
+\\`C-c C-f').  Preview-only buffers are cleaned up when the session
+ends."
   (ast-grep--helm-ensure-function 'helm)
   (ast-grep--reset-candidate-table)
   (helm :sources (ast-grep--helm-source directory)

--- a/ast-grep-helm.el
+++ b/ast-grep-helm.el
@@ -47,7 +47,9 @@
     (unless command
       (error "Helm pattern is shorter than `ast-grep-async-min-input'"))
     (ast-grep--reset-candidate-table)
-    (apply #'start-process "ast-grep-helm" nil command)))
+    (let ((process-connection-type nil)
+          (coding-system-for-read 'utf-8))
+      (apply #'start-process "ast-grep-helm" nil command))))
 
 (defun ast-grep--helm-display-candidate (candidate)
   "Return a Helm display/real pair for CANDIDATE."

--- a/ast-grep-helm.el
+++ b/ast-grep-helm.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Keywords: tools, matching
 
 ;; This file is not part of GNU Emacs.

--- a/ast-grep-ivy.el
+++ b/ast-grep-ivy.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Keywords: tools, matching
 
 ;; This file is not part of GNU Emacs.

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -25,6 +25,9 @@
 (declare-function counsel-imenu "counsel")
 (declare-function helm-imenu "helm-imenu")
 (defvar consult-imenu--cache)
+(defvar helm-cached-imenu-alist)
+(defvar helm-cached-imenu-candidates)
+(defvar helm-cached-imenu-tick)
 (defvar ivy-mode)
 (defvar helm-mode)
 
@@ -162,15 +165,24 @@ rather than signalling, since this runs from `imenu-create-index-function'."
        (message "ast-grep outline failed: %s" (error-message-string err))
        nil))))
 
+(defun ast-grep--outline-clear-helm-imenu-cache ()
+  "Invalidate helm-imenu's buffer-local cache when helm-imenu is loaded."
+  (dolist (cache '(helm-cached-imenu-alist
+                   helm-cached-imenu-candidates
+                   helm-cached-imenu-tick))
+    (when (boundp cache)
+      (kill-local-variable cache))))
+
 (defun ast-grep--outline-invalidate-imenu-caches ()
   "Drop cached imenu indexes so a changed index source takes effect.
-imenu caches in `imenu--index-alist' and consult-imenu keeps its own
-buffer-local `consult-imenu--cache'; neither notices a swapped
+imenu caches in `imenu--index-alist'; consult-imenu and helm-imenu keep
+their own buffer-local caches.  None of them notices a swapped
 `imenu-create-index-function'."
   (when (local-variable-p 'imenu--index-alist)
     (setq-local imenu--index-alist nil))
   (when (boundp 'consult-imenu--cache)
-    (kill-local-variable 'consult-imenu--cache)))
+    (kill-local-variable 'consult-imenu--cache))
+  (ast-grep--outline-clear-helm-imenu-cache))
 
 (defvar-local ast-grep--outline-saved-imenu-function 'unset
   "Saved `imenu-create-index-function' from before `ast-grep-outline-mode'.")
@@ -228,6 +240,7 @@ untouched."
         (cache-local (and (boundp 'consult-imenu--cache)
                           (local-variable-p 'consult-imenu--cache)))
         (saved-cache (and (boundp 'consult-imenu--cache) consult-imenu--cache))
+        helm-cache-touched
         (imenu-auto-rescan t))
     (unwind-protect
         (progn
@@ -245,7 +258,10 @@ untouched."
            ;; back to built-in imenu, never consult.
            ((bound-and-true-p helm-mode)
             (if (and (require 'helm-imenu nil t) (fboundp 'helm-imenu))
-                (call-interactively #'helm-imenu)
+                (progn
+                  (setq helm-cache-touched t)
+                  (ast-grep--outline-clear-helm-imenu-cache)
+                  (call-interactively #'helm-imenu))
               (call-interactively #'imenu)))
            ((and (require 'consult-imenu nil t) (fboundp 'consult-imenu))
             ;; consult-imenu caches per `buffer-modified-tick' and ignores
@@ -261,7 +277,9 @@ untouched."
       (when (boundp 'consult-imenu--cache)
         (if cache-local
             (setq-local consult-imenu--cache saved-cache)
-          (kill-local-variable 'consult-imenu--cache))))))
+          (kill-local-variable 'consult-imenu--cache)))
+      (when helm-cache-touched
+        (ast-grep--outline-clear-helm-imenu-cache)))))
 
 (provide 'ast-grep-outline)
 

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -233,7 +233,8 @@ untouched."
     (error "The ast-grep executable not found. Please install ast-grep"))
   (unless buffer-file-name
     (user-error "Current buffer is not visiting a file"))
-  (let ((saved-fn (if (local-variable-p 'imenu-create-index-function)
+  (let ((origin-buffer (current-buffer))
+        (saved-fn (if (local-variable-p 'imenu-create-index-function)
                       imenu-create-index-function
                     'unset))
         (saved-alist imenu--index-alist)
@@ -270,16 +271,21 @@ untouched."
             (setq-local consult-imenu--cache nil)
             (call-interactively #'consult-imenu))
            (t (call-interactively #'imenu))))
-      (if (eq saved-fn 'unset)
-          (kill-local-variable 'imenu-create-index-function)
-        (setq-local imenu-create-index-function saved-fn))
-      (setq imenu--index-alist saved-alist)
-      (when (boundp 'consult-imenu--cache)
-        (if cache-local
-            (setq-local consult-imenu--cache saved-cache)
-          (kill-local-variable 'consult-imenu--cache)))
-      (when helm-cache-touched
-        (ast-grep--outline-clear-helm-imenu-cache)))))
+      ;; A picker action may leave another buffer current when it returns
+      ;; (e.g. helm-imenu's quit-and-find-file on C-x C-f), so pin the
+      ;; cleanup to the buffer whose imenu state was swapped.
+      (when (buffer-live-p origin-buffer)
+        (with-current-buffer origin-buffer
+          (if (eq saved-fn 'unset)
+              (kill-local-variable 'imenu-create-index-function)
+            (setq-local imenu-create-index-function saved-fn))
+          (setq imenu--index-alist saved-alist)
+          (when (boundp 'consult-imenu--cache)
+            (if cache-local
+                (setq-local consult-imenu--cache saved-cache)
+              (kill-local-variable 'consult-imenu--cache)))
+          (when helm-cache-touched
+            (ast-grep--outline-clear-helm-imenu-cache)))))))
 
 (provide 'ast-grep-outline)
 

--- a/ast-grep-sync.el
+++ b/ast-grep-sync.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Keywords: tools, matching
 
 ;; This file is not part of GNU Emacs.

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -35,7 +35,7 @@
 ;; - Project-wide search
 ;; - Integration with completing-read (Vertico, etc.)
 ;; - Streaming JSON parsing for efficient processing
-;; - Async search with live results (consult, or counsel/ivy when
+;; - Async search with live results (consult, Helm, or counsel/ivy when
 ;;   `ivy-mode' is active)
 
 ;;; Code:
@@ -45,27 +45,35 @@
 (require 'ast-grep-sync)
 
 (defvar ivy-mode nil)
+(defvar helm-mode nil)
 
 (declare-function ast-grep--consult-available-p "ast-grep-consult")
 (declare-function ast-grep--search-consult "ast-grep-consult")
 (declare-function ast-grep--ivy-available-p "ast-grep-ivy")
 (declare-function ast-grep--search-ivy "ast-grep-ivy")
+(declare-function ast-grep--helm-available-p "ast-grep-helm")
+(declare-function ast-grep--search-helm "ast-grep-helm")
 
 (defcustom ast-grep-search-backend 'auto
   "Backend selector for `ast-grep-search'.
 `auto' (default) picks the best available backend:
  - counsel/ivy async when `ivy-mode' is active and counsel is
    loadable;
- - consult async when consult is loadable and `ivy-mode' is off;
+ - Helm async when `helm-mode' is active and Helm is loadable;
+ - consult async when consult is loadable and neither `ivy-mode' nor
+   `helm-mode' is active;
  - synchronous `completing-read' otherwise.
 `consult' forces the consult async pipeline; falls back to sync if
 consult is not loadable.
 `ivy' forces the counsel/ivy async pipeline; falls back to sync if
 counsel/ivy is not loadable.
+`helm' forces the Helm async pipeline; falls back to sync if Helm is
+not loadable.
 `sync' forces the synchronous `completing-read' path."
   :type '(choice (const :tag "Auto-detect" auto)
                  (const :tag "Consult async" consult)
                  (const :tag "Counsel/ivy async" ivy)
+                 (const :tag "Helm async" helm)
                  (const :tag "Sync completing-read" sync))
   :group 'ast-grep)
 
@@ -79,24 +87,33 @@ counsel/ivy is not loadable.
   (and (require 'ast-grep-ivy nil t)
        (ast-grep--ivy-available-p)))
 
+(defun ast-grep--helm-backend-available-p ()
+  "Return non-nil when the Helm backend and Helm are loadable."
+  (and (require 'ast-grep-helm nil t)
+       (ast-grep--helm-available-p)))
+
 (defun ast-grep--project-root ()
   "Get the current project root directory."
   (when-let ((project (project-current)))
     (project-root project)))
 
 (defun ast-grep--select-backend ()
-  "Return the resolved backend symbol: `consult', `ivy', or `sync'.
+  "Return the resolved backend symbol: `consult', `ivy', `helm', or `sync'.
 Honours `ast-grep-search-backend'.  In `auto' mode, active
-`ivy-mode' suppresses consult because consult async minibuffer hooks
-and ivy's minibuffer management are not compatible."
+`ivy-mode' or `helm-mode' suppresses consult because consult async
+minibuffer hooks and those UIs' minibuffer management are not
+compatible."
   (pcase ast-grep-search-backend
     ('sync 'sync)
     ('consult (if (ast-grep--consult-backend-available-p) 'consult 'sync))
     ('ivy (if (ast-grep--ivy-backend-available-p) 'ivy 'sync))
+    ('helm (if (ast-grep--helm-backend-available-p) 'helm 'sync))
     ('auto
      (if (bound-and-true-p ivy-mode)
          (if (ast-grep--ivy-backend-available-p) 'ivy 'sync)
-       (if (ast-grep--consult-backend-available-p) 'consult 'sync)))))
+       (if (bound-and-true-p helm-mode)
+           (if (ast-grep--helm-backend-available-p) 'helm 'sync)
+         (if (ast-grep--consult-backend-available-p) 'consult 'sync))))))
 
 (defun ast-grep--run-search-backend (backend directory)
   "Run BACKEND for ast-grep search in DIRECTORY."
@@ -107,6 +124,9 @@ and ivy's minibuffer management are not compatible."
     ('ivy
      (require 'ast-grep-ivy)
      (ast-grep--search-ivy directory))
+    ('helm
+     (require 'ast-grep-helm)
+     (ast-grep--search-helm directory))
     ('sync (ast-grep--search-sync directory))))
 
 (defun ast-grep--backend-description ()
@@ -136,9 +156,10 @@ DIRECTORY defaults to current directory.
 
 The backend is chosen by `ast-grep-search-backend'.  In the default
 `auto' mode you get the counsel/ivy async pipeline when `ivy-mode' is
-active and counsel is available, the consult async pipeline when
-consult is available and ivy is inactive, and a synchronous
-`completing-read' fallback otherwise.
+active and counsel is available, the Helm async pipeline when
+`helm-mode' is active and Helm is available, the consult async pipeline
+when consult is available and neither UI mode is active, and a
+synchronous `completing-read' fallback otherwise.
 
 Example patterns:
   console.log($A)     - Find console.log calls

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2025 SunskyXH
 
-;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Author: SunskyXH <sunskyxh@gmail.com>
 ;; Version: 0.4.1
 ;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: tools, matching

--- a/tests/ast-grep-entry-test.el
+++ b/tests/ast-grep-entry-test.el
@@ -12,7 +12,7 @@
 (require 'ast-grep)
 
 (ert-deftest ast-grep-entry-test-select-backend-sync ()
-  "`sync' backend is honoured regardless of consult/ivy availability."
+  "`sync' backend is honoured regardless of async backend availability."
   (let ((ast-grep-search-backend 'sync))
     (should (eq 'sync (ast-grep--select-backend)))))
 
@@ -27,20 +27,24 @@
       (should (eq 'sync (ast-grep--select-backend))))))
 
 (ert-deftest ast-grep-entry-test-select-backend-auto-without-consult ()
-  "Auto backend falls back to sync when neither consult nor ivy is available."
+  "Auto backend falls back to sync when no async backend is available."
   (let ((ast-grep-search-backend 'auto)
-        (ivy-mode nil))
+        (ivy-mode nil)
+        (helm-mode nil))
     (cl-letf (((symbol-function 'ast-grep--consult-backend-available-p)
                (lambda () nil))
               ((symbol-function 'ast-grep--ivy-backend-available-p)
+               (lambda () nil))
+              ((symbol-function 'ast-grep--helm-backend-available-p)
                (lambda () nil)))
       (should (eq 'sync (ast-grep--select-backend))))))
 
 (ert-deftest ast-grep-entry-test-select-backend-auto-with-consult ()
-  "Auto backend picks consult when it is loadable and ivy-mode is off."
+  "Auto backend picks consult when it is loadable and UI modes are off."
   (skip-unless ast-grep-test--consult-available)
   (let ((ast-grep-search-backend 'auto)
-        (ivy-mode nil))
+        (ivy-mode nil)
+        (helm-mode nil))
     (should (eq 'consult (ast-grep--select-backend)))))
 
 (ert-deftest ast-grep-entry-test-select-backend-auto-with-ivy-and-counsel ()
@@ -53,6 +57,28 @@
                (lambda () t)))
       (should (eq 'ivy (ast-grep--select-backend))))))
 
+(ert-deftest ast-grep-entry-test-select-backend-auto-with-helm ()
+  "Auto backend picks Helm when `helm-mode' is active and Helm is available."
+  (let ((ast-grep-search-backend 'auto)
+        (ivy-mode nil)
+        (helm-mode t))
+    (cl-letf (((symbol-function 'ast-grep--helm-backend-available-p)
+               (lambda () t))
+              ((symbol-function 'ast-grep--consult-backend-available-p)
+               (lambda () t)))
+      (should (eq 'helm (ast-grep--select-backend))))))
+
+(ert-deftest ast-grep-entry-test-select-backend-auto-with-helm-no-helm ()
+  "Auto falls back to sync when `helm-mode' is on but Helm is missing."
+  (let ((ast-grep-search-backend 'auto)
+        (ivy-mode nil)
+        (helm-mode t))
+    (cl-letf (((symbol-function 'ast-grep--helm-backend-available-p)
+               (lambda () nil))
+              ((symbol-function 'ast-grep--consult-backend-available-p)
+               (lambda () t)))
+      (should (eq 'sync (ast-grep--select-backend))))))
+
 (ert-deftest ast-grep-entry-test-select-backend-force-consult-without-consult ()
   "Forced `consult' falls back to sync when consult is not loadable."
   (let ((ast-grep-search-backend 'consult))
@@ -64,6 +90,13 @@
   "Forced `ivy' falls back to sync when counsel/ivy are not loadable."
   (let ((ast-grep-search-backend 'ivy))
     (cl-letf (((symbol-function 'ast-grep--ivy-backend-available-p)
+               (lambda () nil)))
+      (should (eq 'sync (ast-grep--select-backend))))))
+
+(ert-deftest ast-grep-entry-test-select-backend-force-helm-without-helm ()
+  "Forced `helm' falls back to sync when Helm is not loadable."
+  (let ((ast-grep-search-backend 'helm))
+    (cl-letf (((symbol-function 'ast-grep--helm-backend-available-p)
                (lambda () nil)))
       (should (eq 'sync (ast-grep--select-backend))))))
 
@@ -134,6 +167,27 @@
                        directory-called directory))))
       (ast-grep-search ast-grep-test--fixtures-dir)
       (should (eq backend-called 'ivy))
+      (should (equal directory-called ast-grep-test--fixtures-dir)))))
+
+(ert-deftest ast-grep-entry-test-search-with-helm-mode-dispatches-helm ()
+  "With Helm mode active and Helm available, route to Helm, not consult."
+  (let ((ast-grep-search-backend 'auto)
+        (ivy-mode nil)
+        (helm-mode t)
+        backend-called
+        directory-called)
+    (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+               (lambda () t))
+              ((symbol-function 'ast-grep--helm-backend-available-p)
+               (lambda () t))
+              ((symbol-function 'ast-grep--consult-backend-available-p)
+               (lambda () t))
+              ((symbol-function 'ast-grep--run-search-backend)
+               (lambda (backend directory)
+                 (setq backend-called backend
+                       directory-called directory))))
+      (ast-grep-search ast-grep-test--fixtures-dir)
+      (should (eq backend-called 'helm))
       (should (equal directory-called ast-grep-test--fixtures-dir)))))
 
 (ert-deftest ast-grep-entry-test-rewrite-applies-yes-to-all ()

--- a/tests/ast-grep-helm-test.el
+++ b/tests/ast-grep-helm-test.el
@@ -31,18 +31,26 @@
                           :start-line 0
                           :start-column 0
                           :text "stale")))
-        captured)
+        captured
+        captured-connection-type
+        captured-coding-system)
     (should (ast-grep--candidate-match candidate))
     (cl-letf (((symbol-function 'start-process)
-               (lambda (&rest args)
-                 (setq captured args)
-                 'process)))
-      (should (eq (ast-grep--helm-candidates-process "/dir") 'process))
-      (should (equal captured
-                     '("ast-grep-helm" nil "ast-grep" "run"
-                       "--pattern=abc" "--json=stream" "/dir")))
-      (should-not (gethash (substring-no-properties candidate)
-                           ast-grep--candidate-table)))))
+              (lambda (&rest args)
+                (setq captured args)
+                (setq captured-connection-type process-connection-type)
+                (setq captured-coding-system coding-system-for-read)
+                'process)))
+      (let ((process-connection-type t)
+            (coding-system-for-read 'iso-latin-1))
+        (should (eq (ast-grep--helm-candidates-process "/dir") 'process))
+        (should (equal captured
+                       '("ast-grep-helm" nil "ast-grep" "run"
+                         "--pattern=abc" "--json=stream" "/dir")))
+        (should-not captured-connection-type)
+        (should (eq captured-coding-system 'utf-8))
+        (should-not (gethash (substring-no-properties candidate)
+                             ast-grep--candidate-table))))))
 
 (ert-deftest ast-grep-helm-test-candidates-process-rejects-short-input ()
   "Calling the process builder below the min-input threshold is an error."

--- a/tests/ast-grep-helm-test.el
+++ b/tests/ast-grep-helm-test.el
@@ -110,7 +110,9 @@
                     #'ast-grep--helm-filter-one-by-one))
         (should (eq (plist-get slots :action) #'ast-grep--helm-action))
         (should (eq (plist-get slots :persistent-action)
-                    #'ast-grep--helm-action))
+                    #'ast-grep--helm-preview))
+        (should (eq (plist-get slots :cleanup) #'ast-grep--helm-cleanup))
+        (should (eql (plist-get slots :follow) 1))
         (should (eq (plist-get slots :requires-pattern)
                     ast-grep-async-min-input))))))
 
@@ -121,7 +123,42 @@
     (should (equal (assoc-default 'name source) "ast-grep"))
     (should (eq (assoc-default 'requires-pattern source)
                 ast-grep-async-min-input))
+    (should (eql (assoc-default 'follow source) 1))
     (should (functionp (assoc-default 'candidates-process source)))))
+
+(ert-deftest ast-grep-helm-test-preview-cleans-up-preview-buffers ()
+  "Preview-opened buffers die with the session; pre-existing ones survive.
+Mirrors the consult backend's preview semantics: previewing must not
+leave stray buffers behind, but a buffer the user already had open is
+never killed."
+  (skip-unless (not (find-buffer-visiting ast-grep-test--sample-file)))
+  (let ((selection (ast-grep--format-candidate
+                    (list :file ast-grep-test--sample-file
+                          :start-line 4
+                          :start-column 2
+                          :text "console.log(name)")))
+        (ast-grep--helm-preview-buffers nil))
+    (cl-letf (((symbol-function 'pulse-momentary-highlight-one-line)
+               (lambda (&rest _))))
+      (unwind-protect
+          (progn
+            ;; Not previously visited: preview records the buffer...
+            (ast-grep--helm-preview selection)
+            (should (= (length ast-grep--helm-preview-buffers) 1))
+            (should (buffer-live-p (car ast-grep--helm-preview-buffers)))
+            (should (equal (buffer-file-name) ast-grep-test--sample-file))
+            ;; ...and cleanup kills it and empties the registry.
+            (ast-grep--helm-cleanup)
+            (should-not ast-grep--helm-preview-buffers)
+            (should-not (find-buffer-visiting ast-grep-test--sample-file))
+            ;; Already visited: preview records nothing, cleanup keeps it.
+            (let ((existing (find-file-noselect ast-grep-test--sample-file)))
+              (ast-grep--helm-preview selection)
+              (should-not ast-grep--helm-preview-buffers)
+              (ast-grep--helm-cleanup)
+              (should (buffer-live-p existing))))
+        (when-let ((buf (find-buffer-visiting ast-grep-test--sample-file)))
+          (kill-buffer buf))))))
 
 (ert-deftest ast-grep-helm-test-search-wires-helm-call ()
   "`ast-grep--search-helm' creates the source and starts Helm."

--- a/tests/ast-grep-helm-test.el
+++ b/tests/ast-grep-helm-test.el
@@ -12,14 +12,21 @@
 (require 'ast-grep-helm)
 
 (ert-deftest ast-grep-helm-test-command-respects-min-input ()
-  "Builder returns nil when input is shorter than `ast-grep-async-min-input'."
+  "Builder returns nil when input is narrower than `ast-grep-async-min-input'."
   (let ((ast-grep-async-min-input 3)
         (ast-grep-executable "ast-grep"))
     (should-not (ast-grep--helm-command "" "/dir"))
     (should-not (ast-grep--helm-command "ab" "/dir"))
     (should (equal (ast-grep--helm-command "abc" "/dir")
                    '("ast-grep" "run" "--pattern=abc"
-                     "--json=stream" "/dir")))))
+                     "--json=stream" "/dir")))
+    ;; Helm gates `:requires-pattern' by `string-width', so the builder
+    ;; must measure the same way: "日本" is length 2 but width 4, and a
+    ;; length-based check here would error inside helm's update cycle.
+    (should (equal (ast-grep--helm-command "日本" "/dir")
+                   '("ast-grep" "run" "--pattern=日本"
+                     "--json=stream" "/dir")))
+    (should-not (ast-grep--helm-command "日" "/dir"))))
 
 (ert-deftest ast-grep-helm-test-candidates-process-starts-command ()
   "The Helm adapter starts ast-grep directly with argv, not a shell string."

--- a/tests/ast-grep-helm-test.el
+++ b/tests/ast-grep-helm-test.el
@@ -1,0 +1,172 @@
+;;; ast-grep-helm-test.el --- Helm backend tests for ast-grep.el -*- lexical-binding: t -*-
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Tests for ast-grep.el.
+
+;;; Code:
+
+(require 'ast-grep-test-helper)
+(require 'ast-grep-helm)
+
+(ert-deftest ast-grep-helm-test-command-respects-min-input ()
+  "Builder returns nil when input is shorter than `ast-grep-async-min-input'."
+  (let ((ast-grep-async-min-input 3)
+        (ast-grep-executable "ast-grep"))
+    (should-not (ast-grep--helm-command "" "/dir"))
+    (should-not (ast-grep--helm-command "ab" "/dir"))
+    (should (equal (ast-grep--helm-command "abc" "/dir")
+                   '("ast-grep" "run" "--pattern=abc"
+                     "--json=stream" "/dir")))))
+
+(ert-deftest ast-grep-helm-test-candidates-process-starts-command ()
+  "The Helm adapter starts ast-grep directly with argv, not a shell string."
+  (let ((ast-grep-async-min-input 3)
+        (ast-grep-executable "ast-grep")
+        (helm-pattern "abc")
+        (candidate (ast-grep--format-candidate
+                    (list :file "stale.js"
+                          :start-line 0
+                          :start-column 0
+                          :text "stale")))
+        captured)
+    (should (ast-grep--candidate-match candidate))
+    (cl-letf (((symbol-function 'start-process)
+               (lambda (&rest args)
+                 (setq captured args)
+                 'process)))
+      (should (eq (ast-grep--helm-candidates-process "/dir") 'process))
+      (should (equal captured
+                     '("ast-grep-helm" nil "ast-grep" "run"
+                       "--pattern=abc" "--json=stream" "/dir")))
+      (should-not (gethash (substring-no-properties candidate)
+                           ast-grep--candidate-table)))))
+
+(ert-deftest ast-grep-helm-test-candidates-process-rejects-short-input ()
+  "Calling the process builder below the min-input threshold is an error."
+  (let ((ast-grep-async-min-input 3)
+        (helm-pattern "ab"))
+    (should-error (ast-grep--helm-candidates-process "/dir"))))
+
+(ert-deftest ast-grep-helm-test-filter-one-by-one-parses-json ()
+  "The Helm line transformer registers matches and returns display/real pairs."
+  (let ((ast-grep-use-nerd-icons nil))
+    (ast-grep--reset-candidate-table)
+    (let ((candidate
+           (ast-grep--helm-filter-one-by-one
+            "{\"file\":\"a:b.js\",\"range\":{\"start\":{\"line\":0,\"column\":0}},\"text\":\"x:y\"}")))
+      (should (consp candidate))
+      (should (equal (substring-no-properties (car candidate))
+                     "a:b.js:1:0:x:y"))
+      (should (equal (substring-no-properties (cdr candidate))
+                     "a:b.js:1:0:x:y"))
+      (let ((match (ast-grep--candidate-match (cdr candidate))))
+        (should (equal (plist-get match :file) "a:b.js"))
+        (should (= (plist-get match :start-line) 0))
+        (should (= (plist-get match :start-column) 0))
+        (should (equal (plist-get match :text) "x:y"))))))
+
+(ert-deftest ast-grep-helm-test-filter-one-by-one-ignores-invalid-json ()
+  "Malformed process lines are dropped."
+  (should-not (ast-grep--helm-filter-one-by-one "not json")))
+
+(ert-deftest ast-grep-helm-test-source-wires-helm-slots ()
+  "The Helm source uses async process slots and shared candidate actions."
+  (let (captured proc-directory)
+    (cl-letf (((symbol-function 'helm-make-source)
+               (lambda (&rest args)
+                 (setq captured args)
+                 args))
+              ((symbol-function 'ast-grep--helm-candidates-process)
+               (lambda (directory)
+                 (setq proc-directory directory)
+                 'process)))
+      (let* ((source (ast-grep--helm-source "/dir"))
+             (slots (cddr source))
+             (candidate-process (plist-get slots :candidates-process)))
+        (should (equal (car source) "ast-grep"))
+        (should (eq (cadr source) 'helm-source-async))
+        (should (functionp candidate-process))
+        (should (eq (funcall candidate-process) 'process))
+        (should (equal proc-directory "/dir"))
+        (should (eq (plist-get slots :filter-one-by-one)
+                    #'ast-grep--helm-filter-one-by-one))
+        (should (eq (plist-get slots :action) #'ast-grep--helm-action))
+        (should (eq (plist-get slots :persistent-action)
+                    #'ast-grep--helm-action))
+        (should (eq (plist-get slots :requires-pattern)
+                    ast-grep-async-min-input))))))
+
+(ert-deftest ast-grep-helm-test-real-source-builds-in-backend-sandbox ()
+  "The Helm source constructor works with the real Helm slot API."
+  (skip-unless ast-grep-test--helm-available)
+  (let ((source (ast-grep--helm-source ast-grep-test--fixtures-dir)))
+    (should (equal (assoc-default 'name source) "ast-grep"))
+    (should (eq (assoc-default 'requires-pattern source)
+                ast-grep-async-min-input))
+    (should (functionp (assoc-default 'candidates-process source)))))
+
+(ert-deftest ast-grep-helm-test-search-wires-helm-call ()
+  "`ast-grep--search-helm' creates the source and starts Helm."
+  (let (helm-args source-directory)
+    (cl-letf (((symbol-function 'ast-grep--helm-source)
+               (lambda (directory)
+                 (setq source-directory directory)
+                 'source))
+              ((symbol-function 'helm)
+               (lambda (&rest args)
+                 (setq helm-args args)
+                 'helm-result)))
+      (should (eq (ast-grep--search-helm ast-grep-test--fixtures-dir)
+                  'helm-result))
+      (should (equal source-directory ast-grep-test--fixtures-dir))
+      (should (eq (plist-get helm-args :sources) 'source))
+      (should (equal (plist-get helm-args :prompt) "ast-grep: "))
+      (should (equal (plist-get helm-args :buffer) "*helm ast-grep*"))
+      (should (eq (plist-get helm-args :history) 'ast-grep-history)))))
+
+(ert-deftest ast-grep-helm-test-action-wires-goto-match ()
+  "The Helm action visits the selected match and pulses the destination."
+  (let* ((selection (ast-grep--format-candidate
+                     (list :file ast-grep-test--sample-file
+                           :start-line 4
+                           :start-column 2
+                           :text "console.log(name)")))
+         (buffer-before (find-buffer-visiting ast-grep-test--sample-file))
+         (pulse-calls 0))
+    (cl-letf (((symbol-function 'pulse-momentary-highlight-one-line)
+               (lambda (&rest _) (cl-incf pulse-calls))))
+      (unwind-protect
+          (progn
+            (ast-grep--helm-action selection)
+            (should (equal (buffer-file-name) ast-grep-test--sample-file))
+            (should (= (line-number-at-pos) 5))
+            (should (= (current-column) 2))
+            (should (= pulse-calls 1)))
+        (unless buffer-before
+          (when-let ((buf (find-buffer-visiting ast-grep-test--sample-file)))
+            (kill-buffer buf)))))))
+
+(ert-deftest ast-grep-helm-test-action-ignores-non-candidates ()
+  "The Helm action ignores placeholder text and unmatched strings."
+  (let ((find-file-calls 0)
+        (pulse-calls 0))
+    (cl-letf (((symbol-function 'find-file)
+               (lambda (&rest _) (cl-incf find-file-calls)))
+              ((symbol-function 'pulse-momentary-highlight-one-line)
+               (lambda (&rest _) (cl-incf pulse-calls))))
+      (should-not (ast-grep--helm-action "not a candidate"))
+      (should (zerop find-file-calls))
+      (should (zerop pulse-calls)))))
+
+(ert-deftest ast-grep-helm-test-helm-available-in-backend-sandbox ()
+  "Helm backend sandboxes must load real Helm."
+  (skip-unless (member (getenv "AST_GREP_TEST_BACKEND") '("helm" "full")))
+  (should ast-grep-test--helm-available)
+  (should (ast-grep--helm-available-p)))
+
+(provide 'ast-grep-helm-test)
+
+;;; ast-grep-helm-test.el ends here

--- a/tests/ast-grep-helm-test.el
+++ b/tests/ast-grep-helm-test.el
@@ -21,12 +21,12 @@
                    '("ast-grep" "run" "--pattern=abc"
                      "--json=stream" "/dir")))
     ;; Helm gates `:requires-pattern' by `string-width', so the builder
-    ;; must measure the same way: "日本" is length 2 but width 4, and a
+    ;; must measure the same way: "文字" is length 2 but width 4, and a
     ;; length-based check here would error inside helm's update cycle.
-    (should (equal (ast-grep--helm-command "日本" "/dir")
-                   '("ast-grep" "run" "--pattern=日本"
+    (should (equal (ast-grep--helm-command "文字" "/dir")
+                   '("ast-grep" "run" "--pattern=文字"
                      "--json=stream" "/dir")))
-    (should-not (ast-grep--helm-command "日" "/dir"))))
+    (should-not (ast-grep--helm-command "文" "/dir"))))
 
 (ert-deftest ast-grep-helm-test-candidates-process-starts-command ()
   "The Helm adapter starts ast-grep directly with argv, not a shell string."
@@ -43,11 +43,11 @@
         captured-coding-system)
     (should (ast-grep--candidate-match candidate))
     (cl-letf (((symbol-function 'start-process)
-              (lambda (&rest args)
-                (setq captured args)
-                (setq captured-connection-type process-connection-type)
-                (setq captured-coding-system coding-system-for-read)
-                'process)))
+               (lambda (&rest args)
+                 (setq captured args)
+                 (setq captured-connection-type process-connection-type)
+                 (setq captured-coding-system coding-system-for-read)
+                 'process)))
       (let ((process-connection-type t)
             (coding-system-for-read 'iso-latin-1))
         (should (eq (ast-grep--helm-candidates-process "/dir") 'process))

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -271,13 +271,27 @@ installed in the current sandbox."
   (with-temp-buffer
     (setq buffer-file-name "x.ts")
     (setq-local imenu--index-alist '(("old" . 1)))
+    (setq-local helm-cached-imenu-alist '(("old" . 1)))
+    (setq-local helm-cached-imenu-candidates '(("old" . 1)))
+    (setq-local helm-cached-imenu-tick (buffer-modified-tick))
     (ast-grep-outline-mode 1)
     ;; Enabling drops the index built by the previous source.
     (should-not imenu--index-alist)
+    (dolist (cache '(helm-cached-imenu-alist
+                     helm-cached-imenu-candidates
+                     helm-cached-imenu-tick))
+      (should-not (local-variable-p cache)))
     (setq-local imenu--index-alist '(("ours" . 2)))
+    (setq-local helm-cached-imenu-alist '(("ours" . 2)))
+    (setq-local helm-cached-imenu-candidates '(("ours" . 2)))
+    (setq-local helm-cached-imenu-tick (buffer-modified-tick))
     (ast-grep-outline-mode -1)
     ;; Disabling drops our index so the restored source rebuilds.
-    (should-not imenu--index-alist)))
+    (should-not imenu--index-alist)
+    (dolist (cache '(helm-cached-imenu-alist
+                     helm-cached-imenu-candidates
+                     helm-cached-imenu-tick))
+      (should-not (local-variable-p cache)))))
 
 (ert-deftest ast-grep-outline-test-degrades-without-outline-support ()
   "An ast-grep without `outline' yields an empty index, never an error.
@@ -328,19 +342,70 @@ Runs in the consult sandbox, where consult is present but counsel is not."
         (should (eq called 'imenu))))))
 
 (ert-deftest ast-grep-outline-test-command-dispatches-helm-when-helm ()
-  "With `helm-mode' active and Helm available, dispatch to helm-imenu."
+  "With `helm-mode' active, dispatch to helm-imenu with fresh caches."
   (skip-unless (require 'helm-imenu nil t))
   (with-temp-buffer
     (setq buffer-file-name "x.ts")
     (let ((ivy-mode nil)
           (helm-mode t)
-          (called nil))
+          (called nil)
+          tick-at-dispatch
+          candidates-at-dispatch
+          alist-at-dispatch)
+      (setq-local helm-cached-imenu-alist '(("old" . 1)))
+      (setq-local helm-cached-imenu-candidates '(("old" . 1)))
+      (setq-local helm-cached-imenu-tick (buffer-modified-tick))
       (cl-letf (((symbol-function 'ast-grep--executable-available-p)
                  (lambda () t))
                 ((symbol-function 'helm-imenu)
-                 (lambda (&rest _) (interactive) (setq called 'helm))))
+                 (lambda (&rest _)
+                   (interactive)
+                   (setq called 'helm
+                         alist-at-dispatch helm-cached-imenu-alist
+                         candidates-at-dispatch helm-cached-imenu-candidates
+                         tick-at-dispatch helm-cached-imenu-tick)
+                   ;; Simulate helm-imenu rebuilding and writing ast-grep
+                   ;; candidates during this one-shot command.
+                   (setq-local helm-cached-imenu-alist '(("outline" . 2)))
+                   (setq-local helm-cached-imenu-candidates '(("outline" . 2)))
+                   (setq-local helm-cached-imenu-tick
+                               (buffer-modified-tick)))))
         (ast-grep-outline)
-        (should (eq called 'helm))))))
+        (should (eq called 'helm))
+        ;; The stale native helm-imenu cache was cleared before dispatch.
+        (should-not alist-at-dispatch)
+        (should-not candidates-at-dispatch)
+        (should-not tick-at-dispatch)
+        ;; The ast-grep one-shot cache written by helm-imenu is not left
+        ;; behind for a later plain helm-imenu command.
+        (dolist (cache '(helm-cached-imenu-alist
+                         helm-cached-imenu-candidates
+                         helm-cached-imenu-tick))
+          (should-not (local-variable-p cache)))))))
+
+(ert-deftest ast-grep-outline-test-helm-candidates-rebuild-after-cache-clear ()
+  "Clearing helm-imenu's tick cache makes candidates rebuild."
+  (skip-unless (require 'helm-imenu nil t))
+  (with-temp-buffer
+    (ast-grep-outline-test--insert-source)
+    (setq buffer-file-name "x.ts")
+    (setq-local imenu-create-index-function #'ast-grep--outline-imenu-index)
+    (let ((calls 0)
+          (old-candidates '(("old" . 1))))
+      (setq-local helm-cached-imenu-tick (buffer-modified-tick))
+      (setq-local helm-cached-imenu-candidates old-candidates)
+      (cl-letf (((symbol-function 'ast-grep--run-outline)
+                 (lambda (_file)
+                   (setq calls (1+ calls))
+                   ast-grep-outline-test--stream)))
+        ;; The stale tick reproduces helm-imenu's short-circuit.
+        (should (equal (helm-imenu-candidates (current-buffer))
+                       old-candidates))
+        (should (= calls 0))
+        (ast-grep--outline-clear-helm-imenu-cache)
+        (should-not (equal (helm-imenu-candidates (current-buffer))
+                           old-candidates))
+        (should (= calls 1))))))
 
 (ert-deftest ast-grep-outline-test-command-helm-without-helm-uses-imenu ()
   "helm-mode active but Helm missing falls to imenu, never consult.

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -148,6 +148,39 @@ installed in the current sandbox."
         (should-not (local-variable-p 'imenu-create-index-function))
         (should (eq imenu--index-alist 'sentinel))))))
 
+(ert-deftest ast-grep-outline-test-command-cleanup-pins-origin-buffer ()
+  "Cleanup restores the origin buffer even when the picker switches buffers.
+Some picker exits leave another buffer current when they return (e.g.
+helm-imenu's quit-and-find-file on \\`C-x C-f'); the unwind cleanup must
+still target the buffer whose imenu state was swapped, not whichever
+buffer the action landed in."
+  (require 'consult-imenu nil t)
+  (let ((origin (generate-new-buffer " *sg-outline-origin*"))
+        (other (generate-new-buffer " *sg-outline-other*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer origin
+            (setq buffer-file-name "x.ts")
+            (setq-local imenu--index-alist 'sentinel)
+            (let ((ivy-mode nil))
+              (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+                         (lambda () t))
+                        ((symbol-function 'imenu)
+                         (lambda (&rest _) (interactive) (set-buffer other)))
+                        ((symbol-function 'consult-imenu)
+                         (lambda (&rest _) (interactive) (set-buffer other))))
+                (ast-grep-outline))))
+          ;; The origin buffer got its imenu state back...
+          (with-current-buffer origin
+            (should-not (local-variable-p 'imenu-create-index-function))
+            (should (eq imenu--index-alist 'sentinel)))
+          ;; ...and the buffer the picker landed in was left alone.
+          (with-current-buffer other
+            (should-not (local-variable-p 'imenu-create-index-function))
+            (should-not (local-variable-p 'imenu--index-alist))))
+      (kill-buffer origin)
+      (kill-buffer other))))
+
 (ert-deftest ast-grep-outline-test-real-binary-index ()
   "The real outline binary produces the expected index for sample.ts."
   (skip-unless (ast-grep-test--outline-available-p))

--- a/tests/ast-grep-test-helper.el
+++ b/tests/ast-grep-test-helper.el
@@ -15,6 +15,7 @@
 ;; dynamic (visible to `bound-and-true-p').  Without this, lexical-binding
 ;; makes the binding invisible to the backend selector.
 (defvar ivy-mode nil)
+(defvar helm-mode nil)
 (defvar consult-async-input-throttle)
 (defvar consult-async-input-debounce)
 (defvar counsel-async-command-delay)
@@ -45,6 +46,10 @@
   (and (require 'ivy nil t)
        (require 'counsel nil t))
   "Non-nil if ivy and counsel are loadable during this test run.")
+
+(defvar ast-grep-test--helm-available
+  (require 'helm nil t)
+  "Non-nil if Helm is loadable during this test run.")
 
 (defun ast-grep-test--drive-async (source pattern &optional timeout)
   "Drive consult async SOURCE with PATTERN, return collected candidates.

--- a/tests/run-tests.el
+++ b/tests/run-tests.el
@@ -5,7 +5,7 @@
 ;;; Commentary:
 
 ;; Unified ERT entry point.  Set AST_GREP_TEST_BACKEND to sync,
-;; consult, ivy, or full to choose the backend sandbox suite.
+;; consult, ivy, helm, or full to choose the backend sandbox suite.
 
 ;;; Code:
 
@@ -19,6 +19,7 @@
     "ast-grep-sync-test.el"
     "ast-grep-consult-test.el"
     "ast-grep-ivy-test.el"
+    "ast-grep-helm-test.el"
     "ast-grep-entry-test.el")
   "All test files loadable by `ast-grep-test-run-batch'.")
 
@@ -36,6 +37,9 @@
       ("ivy" '("ast-grep-core-test.el"
                "ast-grep-ivy-test.el"
                "ast-grep-entry-test.el"))
+      ("helm" '("ast-grep-core-test.el"
+                "ast-grep-helm-test.el"
+                "ast-grep-entry-test.el"))
       ("full" ast-grep-test--all-test-files)
       (_ ast-grep-test--all-test-files))))
 
@@ -57,6 +61,9 @@
         ("ivy" '(or "^ast-grep-core-test-"
                    "^ast-grep-ivy-test-"
                    "^ast-grep-entry-test-"))
+        ("helm" '(or "^ast-grep-core-test-"
+                    "^ast-grep-helm-test-"
+                    "^ast-grep-entry-test-"))
         ("full" t)
         (_ t))))
 


### PR DESCRIPTION
## Summary

- Add a native Helm backend for async ast-grep search.
- Select Helm automatically when helm-mode is active, while keeping Ivy, Consult, and sync fallback behavior.
- Harden the Helm process path to use a pipe and decode output as UTF-8.
- Add Helm backend tests and update the backend test matrix/docs.

## Validation

- eask run script compile
- eask run script test:sync
- eask run script test:helm
- eask run script test:full