### PR TITLE
feat(outline): add ast-grep outline imenu navigation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,12 +60,9 @@ jobs:
         with:
           version: "0.12.9"
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-
       - name: Install ast-grep
         run: |
-          nix profile install nixpkgs#ast-grep
+          npm install -g @ast-grep/cli@^0.44.0
           ast-grep --version
 
       - name: Byte-compile

--- a/Eask
+++ b/Eask
@@ -15,7 +15,7 @@
 (files "ast-grep*.el")
 
 (script "compile"
-        "eask --strict compile ast-grep-core.el ast-grep-sync.el ast-grep-consult.el ast-grep-ivy.el ast-grep.el")
+        "eask --strict compile ast-grep-core.el ast-grep-sync.el ast-grep-consult.el ast-grep-ivy.el ast-grep-outline.el ast-grep.el")
 
 (script "test"
         "eask emacs -batch -L . -L tests -l tests/run-tests.el -f ast-grep-test-run-batch")

--- a/README.org
+++ b/README.org
@@ -83,7 +83,7 @@ Add to your ~packages.el~:
 - ~ast-grep-describe-backend~ - Show the configured backend selector and resolved backend
 - ~ast-grep-rewrite~ - Interactive search-and-rewrite in current directory
 - ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
-- ~ast-grep-outline~ - Jump to a symbol in the current file (uses ~consult-imenu~ when available, otherwise ~imenu~)
+- ~ast-grep-outline~ - Jump to a symbol in the current file (uses ~counsel-imenu~ when ~ivy-mode~ is active, otherwise ~consult-imenu~, otherwise the built-in ~imenu~)
 
 ~ast-grep-rewrite~ prompts for a pattern and a replacement template,
 then walks each match asking ~y~/~n~/~!~/~q~ (yes / skip /
@@ -96,9 +96,11 @@ save with ~M-x save-some-buffers~ (~C-x s~).
 ~ast-grep-outline~ asks ~ast-grep outline~ for the symbols in the current
 file and lets you jump to one. Symbols are grouped by kind (Classes,
 Functions, Methods, ...) and members are qualified with their enclosing
-type (e.g. ~Widget.render~). It dispatches to ~consult-imenu~ when
-available and falls back to plain ~imenu~ otherwise. The outline is read
-from the file on disk, so save the buffer to keep positions accurate.
+type (e.g. ~Widget.render~). It picks a picker the same way
+~ast-grep-search~ picks a backend: ~counsel-imenu~ when ~ivy-mode~ is
+active, otherwise ~consult-imenu~, otherwise the built-in ~imenu~ (which
+your completion framework still drives). The outline is read from the
+file on disk, so save the buffer to keep positions accurate.
 
 To make ast-grep the imenu source for a buffer permanently, enable
 ~ast-grep-outline-mode~. Every imenu consumer (~imenu~, ~consult-imenu~,

--- a/README.org
+++ b/README.org
@@ -83,7 +83,7 @@ Add to your ~packages.el~:
 - ~ast-grep-describe-backend~ - Show the configured backend selector and resolved backend
 - ~ast-grep-rewrite~ - Interactive search-and-rewrite in current directory
 - ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
-- ~ast-grep-outline~ - Jump to a symbol in the current file (uses ~counsel-imenu~ when ~ivy-mode~ is active, otherwise ~consult-imenu~, otherwise the built-in ~imenu~)
+- ~ast-grep-outline~ - Jump to a symbol in the current file (picker mirrors the ~ast-grep-search~ backend: ~counsel-imenu~ under ~ivy-mode~, otherwise ~consult-imenu~, with the built-in ~imenu~ as the universal fallback)
 
 ~ast-grep-rewrite~ prompts for a pattern and a replacement template,
 then walks each match asking ~y~/~n~/~!~/~q~ (yes / skip /
@@ -97,10 +97,11 @@ save with ~M-x save-some-buffers~ (~C-x s~).
 file and lets you jump to one. Symbols are grouped by kind (Classes,
 Functions, Methods, ...) and members are qualified with their enclosing
 type (e.g. ~Widget.render~). It picks a picker the same way
-~ast-grep-search~ picks a backend: ~counsel-imenu~ when ~ivy-mode~ is
-active, otherwise ~consult-imenu~, otherwise the built-in ~imenu~ (which
-your completion framework still drives). The outline is read from the
-file on disk, so save the buffer to keep positions accurate.
+~ast-grep-search~ picks a backend: under ~ivy-mode~ it uses
+~counsel-imenu~ (never ~consult-imenu~), otherwise ~consult-imenu~ when
+available, always falling back to the built-in ~imenu~ (which your
+completion framework still drives). The outline is read from the file on
+disk, so save the buffer to keep positions accurate.
 
 To make ast-grep the imenu source for a buffer permanently, enable
 ~ast-grep-outline-mode~. Every imenu consumer (~imenu~, ~consult-imenu~,

--- a/README.org
+++ b/README.org
@@ -18,11 +18,13 @@ An Emacs interface to [[https://github.com/ast-grep/ast-grep][ast-grep]], a CLI 
 - Streaming JSON parsing for efficient processing
 - Async search with live results via consult, or via counsel/ivy when ~ivy-mode~ is active
 - Interactive rewrite across files (~project-query-replace-regexp~ style)
+- In-file symbol navigation via ~ast-grep outline~, exposed through ~imenu~ (so ~consult-imenu~, ~counsel-imenu~, ~imenu-list~, ... all work)
 
 ** Requirements
 
 - Emacs 28.1 or later
 - [[https://github.com/ast-grep/ast-grep][ast-grep]] CLI tool installed and available in PATH
+  - The outline navigation commands require ast-grep 0.44.0 or later
 - Optional, for live async search:
   - [[https://github.com/minad/consult][consult]] (pairs with Vertico, Selectrum, etc.), or
   - [[https://github.com/abo-abo/swiper][ivy + counsel]] when ~ivy-mode~ is active
@@ -81,12 +83,35 @@ Add to your ~packages.el~:
 - ~ast-grep-describe-backend~ - Show the configured backend selector and resolved backend
 - ~ast-grep-rewrite~ - Interactive search-and-rewrite in current directory
 - ~ast-grep-rewrite-project~ - Interactive search-and-rewrite across the project
+- ~ast-grep-outline~ - Jump to a symbol in the current file (uses ~consult-imenu~ when available, otherwise ~imenu~)
 
 ~ast-grep-rewrite~ prompts for a pattern and a replacement template,
 then walks each match asking ~y~/~n~/~!~/~q~ (yes / skip /
 apply-all-remaining / quit), following ~query-replace~ conventions like
 ~project-query-replace-regexp~. Modified buffers are left for you to
 save with ~M-x save-some-buffers~ (~C-x s~).
+
+*** Outline navigation (imenu)
+
+~ast-grep-outline~ asks ~ast-grep outline~ for the symbols in the current
+file and lets you jump to one. Symbols are grouped by kind (Classes,
+Functions, Methods, ...) and members are qualified with their enclosing
+type (e.g. ~Widget.render~). It dispatches to ~consult-imenu~ when
+available and falls back to plain ~imenu~ otherwise. The outline is read
+from the file on disk, so save the buffer to keep positions accurate.
+
+To make ast-grep the imenu source for a buffer permanently, enable
+~ast-grep-outline-mode~. Every imenu consumer (~imenu~, ~consult-imenu~,
+~counsel-imenu~, ~imenu-list~, ...) then lists ast-grep's symbols:
+
+#+begin_src emacs-lisp
+;; e.g. use ast-grep's outline for imenu in TypeScript buffers
+(add-hook 'typescript-ts-mode-hook #'ast-grep-outline-mode)
+#+end_src
+
+Outline support covers the languages ast-grep ships outline rules for
+(TypeScript/JavaScript, Python, Go, Rust, Java, ...). Languages without
+outline rules yield an empty index.
 
 *** Minor Mode
 

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -89,7 +89,7 @@ character-index coordinates ast-grep reports."
         (point)))))
 
 (defun ast-grep--outline-flatten (items prefix)
-  "Return flat (TYPE NAME . POSITION) entries for outline ITEMS.
+  "Return flat (TYPE NAME POSITION) entries for outline ITEMS.
 Members are qualified with their enclosing item via PREFIX, e.g.
 \"Widget.render\", and recursion preserves source order."
   (apply
@@ -158,6 +158,16 @@ rather than signalling, since this runs from `imenu-create-index-function'."
        (message "ast-grep outline failed: %s" (error-message-string err))
        nil))))
 
+(defun ast-grep--outline-invalidate-imenu-caches ()
+  "Drop cached imenu indexes so a changed index source takes effect.
+imenu caches in `imenu--index-alist' and consult-imenu keeps its own
+buffer-local `consult-imenu--cache'; neither notices a swapped
+`imenu-create-index-function'."
+  (when (local-variable-p 'imenu--index-alist)
+    (setq-local imenu--index-alist nil))
+  (when (boundp 'consult-imenu--cache)
+    (kill-local-variable 'consult-imenu--cache)))
+
 (defvar-local ast-grep--outline-saved-imenu-function 'unset
   "Saved `imenu-create-index-function' from before `ast-grep-outline-mode'.")
 
@@ -186,7 +196,10 @@ the buffer to keep positions accurate."
         (kill-local-variable 'imenu-create-index-function)
       (setq-local imenu-create-index-function
                   ast-grep--outline-saved-imenu-function))
-    (setq ast-grep--outline-saved-imenu-function 'unset)))
+    (setq ast-grep--outline-saved-imenu-function 'unset))
+  ;; Either toggle changes the index source; drop caches that still reflect
+  ;; the previous one so imenu and consult-imenu rebuild against it.
+  (ast-grep--outline-invalidate-imenu-caches))
 
 ;;;###autoload
 (defun ast-grep-outline ()

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -22,7 +22,9 @@
 (require 'ast-grep-core)
 
 (declare-function consult-imenu "consult-imenu")
+(declare-function counsel-imenu "counsel")
 (defvar consult-imenu--cache)
+(defvar ivy-mode)
 
 (defconst ast-grep--outline-type-titles
   '(("class" . "Classes")
@@ -204,9 +206,11 @@ the buffer to keep positions accurate."
 ;;;###autoload
 (defun ast-grep-outline ()
   "Jump to a symbol in the current file via `ast-grep outline'.
-Dispatch to `consult-imenu' when available, otherwise `imenu'.  This is a
-one-shot entry point: it does not require `ast-grep-outline-mode' and
-leaves the buffer's own imenu configuration untouched."
+Pick the picker the way `ast-grep-search' picks a backend: `counsel-imenu'
+when `ivy-mode' is active and counsel is available, otherwise
+`consult-imenu', otherwise the built-in `imenu'.  This is a one-shot entry
+point: it does not require `ast-grep-outline-mode' and leaves the buffer's
+own imenu configuration untouched."
   (interactive)
   (unless (ast-grep--executable-available-p)
     (error "The ast-grep executable not found. Please install ast-grep"))
@@ -225,14 +229,19 @@ leaves the buffer's own imenu configuration untouched."
           (setq-local imenu-create-index-function
                       #'ast-grep--outline-imenu-index)
           (setq imenu--index-alist nil)
-          (if (and (require 'consult-imenu nil t) (fboundp 'consult-imenu))
-              (progn
-                ;; consult-imenu caches per `buffer-modified-tick' and ignores
-                ;; `imenu--index-alist', so clear its cache to force a recompute
-                ;; against our index.
-                (setq-local consult-imenu--cache nil)
-                (call-interactively #'consult-imenu))
-            (call-interactively #'imenu)))
+          (cond
+           ;; Mirror `ast-grep-search' backend selection: ivy users get
+           ;; counsel-imenu, which reads the same `imenu--index-alist'.
+           ((and (bound-and-true-p ivy-mode)
+                 (require 'counsel nil t) (fboundp 'counsel-imenu))
+            (call-interactively #'counsel-imenu))
+           ((and (require 'consult-imenu nil t) (fboundp 'consult-imenu))
+            ;; consult-imenu caches per `buffer-modified-tick' and ignores
+            ;; `imenu--index-alist', so clear its cache to force a recompute
+            ;; against our index.
+            (setq-local consult-imenu--cache nil)
+            (call-interactively #'consult-imenu))
+           (t (call-interactively #'imenu))))
       (if (eq saved-fn 'unset)
           (kill-local-variable 'imenu-create-index-function)
         (setq-local imenu-create-index-function saved-fn))

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -1,0 +1,234 @@
+;;; ast-grep-outline.el --- imenu index from ast-grep outline -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 SunskyXH
+
+;; Author: SunskyxXH <sunskyxh@gmail.com>
+;; Keywords: tools, matching
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Build an imenu index for the current file from `ast-grep outline'.
+;; Once installed as `imenu-create-index-function', every imenu consumer
+;; (`imenu', `consult-imenu', `counsel-imenu', `imenu-list', ...) can jump
+;; to the symbols ast-grep extracts.  The outline runs against the file on
+;; disk, so positions are accurate for a saved buffer.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'imenu)
+(require 'ast-grep-core)
+
+(declare-function consult-imenu "consult-imenu")
+(defvar consult-imenu--cache)
+
+(defconst ast-grep--outline-type-titles
+  '(("class" . "Classes")
+    ("interface" . "Interfaces")
+    ("struct" . "Structs")
+    ("enum" . "Enums")
+    ("trait" . "Traits")
+    ("object" . "Objects")
+    ("module" . "Modules")
+    ("namespace" . "Namespaces")
+    ("function" . "Functions")
+    ("method" . "Methods")
+    ("constructor" . "Constructors")
+    ("field" . "Fields")
+    ("property" . "Properties")
+    ("constant" . "Constants")
+    ("variable" . "Variables")
+    ("type" . "Types")
+    ("macro" . "Macros"))
+  "Map ast-grep outline symbol types to imenu group titles.
+The order also fixes how groups are sorted in the index, so symbols of
+the same kind always appear in the same place regardless of source order.")
+
+(defun ast-grep--outline-group-title (type)
+  "Return the imenu group title for outline symbol TYPE.
+Unknown types fall back to a capitalized form of TYPE."
+  (or (cdr (assoc type ast-grep--outline-type-titles))
+      (capitalize (or type "Other"))))
+
+(defun ast-grep--build-outline-command (file)
+  "Build the `ast-grep outline' command for FILE."
+  (list ast-grep-executable "outline" "--json=stream" (expand-file-name file)))
+
+(defun ast-grep--run-outline (file)
+  "Run `ast-grep outline' on FILE and return its raw stdout."
+  (ast-grep--call (ast-grep--build-outline-command file) nil "outline"))
+
+(defun ast-grep--outline-parse (output)
+  "Parse outline stream OUTPUT into a flat list of top-level item plists.
+OUTPUT holds one JSON object per file; items from every object are
+collected so multi-file output degrades gracefully."
+  (when (and output (not (string-empty-p output)))
+    (apply #'append
+           (delq nil
+                 (mapcar
+                  (lambda (line)
+                    (condition-case nil
+                        (plist-get (json-parse-string
+                                    line :object-type 'plist :array-type 'list)
+                                   :items)
+                      (error nil)))
+                  (split-string output "\n" t))))))
+
+(defun ast-grep--outline-item-position (item)
+  "Return the buffer position of outline ITEM's start, or nil.
+The position is computed in the current buffer using the same
+character-index coordinates ast-grep reports."
+  (let* ((start (plist-get (plist-get item :range) :start))
+         (line (plist-get start :line))
+         (column (plist-get start :column)))
+    (when (and line column)
+      (save-excursion
+        (ast-grep--goto-line-column line column)
+        (point)))))
+
+(defun ast-grep--outline-flatten (items prefix)
+  "Return flat (TYPE NAME . POSITION) entries for outline ITEMS.
+Members are qualified with their enclosing item via PREFIX, e.g.
+\"Widget.render\", and recursion preserves source order."
+  (apply
+   #'append
+   (mapcar
+    (lambda (item)
+      (let* ((raw-name (plist-get item :name))
+             (name (and (stringp raw-name) raw-name))
+             (qualified (if (and prefix name) (concat prefix "." name) name))
+             (pos (and name (ast-grep--outline-item-position item)))
+             (self (when (and name pos)
+                     (list (list (plist-get item :symbolType) qualified pos)))))
+        (append self
+                (ast-grep--outline-flatten (plist-get item :members) qualified))))
+    items)))
+
+(defun ast-grep--outline-dedupe-names (leaves)
+  "Make duplicate display names in LEAVES unique so every entry is reachable.
+imenu resolves a selection with `assoc', which only finds the first leaf
+of a given name; later duplicates become \"NAME<2>\", \"NAME<3>\", ...
+Positions are untouched."
+  (let ((counts (make-hash-table :test 'equal)))
+    (mapcar
+     (lambda (leaf)
+       (let ((seen (1+ (gethash (car leaf) counts 0))))
+         (puthash (car leaf) seen counts)
+         (if (= seen 1)
+             leaf
+           (cons (format "%s<%d>" (car leaf) seen) (cdr leaf)))))
+     leaves)))
+
+(defun ast-grep--outline-group (entries)
+  "Group flat ENTRIES into an imenu index alist.
+Each group is (TITLE (NAME . POS) ...); groups are ordered by
+`ast-grep--outline-type-titles' and entries keep source order."
+  (let ((groups nil)
+        (order (mapcar #'cdr ast-grep--outline-type-titles)))
+    (dolist (entry entries)
+      (let* ((title (ast-grep--outline-group-title (nth 0 entry)))
+             (cell (assoc title groups)))
+        (if cell
+            (setcdr cell (cons (cons (nth 1 entry) (nth 2 entry)) (cdr cell)))
+          (push (cons title (list (cons (nth 1 entry) (nth 2 entry)))) groups))))
+    (mapcar (lambda (group)
+              (cons (car group)
+                    (ast-grep--outline-dedupe-names (nreverse (cdr group)))))
+            (sort (nreverse groups)
+                  (lambda (a b)
+                    (< (or (cl-position (car a) order :test #'equal)
+                           most-positive-fixnum)
+                       (or (cl-position (car b) order :test #'equal)
+                           most-positive-fixnum)))))))
+
+(defun ast-grep--outline-imenu-index ()
+  "Build an imenu index for the current file using `ast-grep outline'.
+Return nil when the buffer has no file or ast-grep finds no symbols.
+A failing or too-old (<0.44.0) ast-grep degrades to an empty index
+rather than signalling, since this runs from `imenu-create-index-function'."
+  (when buffer-file-name
+    (condition-case err
+        (ast-grep--outline-group
+         (ast-grep--outline-flatten
+          (ast-grep--outline-parse (ast-grep--run-outline buffer-file-name))
+          nil))
+      (error
+       (message "ast-grep outline failed: %s" (error-message-string err))
+       nil))))
+
+(defvar-local ast-grep--outline-saved-imenu-function 'unset
+  "Saved `imenu-create-index-function' from before `ast-grep-outline-mode'.")
+
+;;;###autoload
+(define-minor-mode ast-grep-outline-mode
+  "Use `ast-grep outline' as this buffer's imenu index source.
+While enabled, `imenu', `consult-imenu', `counsel-imenu' and other imenu
+consumers list the symbols ast-grep extracts from the file on disk.  Save
+the buffer to keep positions accurate."
+  :lighter " sg-outline"
+  (if ast-grep-outline-mode
+      (progn
+        ;; Record the prior function only the first time we install ours, so a
+        ;; re-entrant enable never captures `ast-grep--outline-imenu-index'
+        ;; itself and disable can still restore the genuine prior value.
+        (when (and (eq ast-grep--outline-saved-imenu-function 'unset)
+                   (not (eq imenu-create-index-function
+                            #'ast-grep--outline-imenu-index)))
+          (setq ast-grep--outline-saved-imenu-function
+                (if (local-variable-p 'imenu-create-index-function)
+                    imenu-create-index-function
+                  'unset)))
+        (setq-local imenu-create-index-function
+                    #'ast-grep--outline-imenu-index))
+    (if (eq ast-grep--outline-saved-imenu-function 'unset)
+        (kill-local-variable 'imenu-create-index-function)
+      (setq-local imenu-create-index-function
+                  ast-grep--outline-saved-imenu-function))
+    (setq ast-grep--outline-saved-imenu-function 'unset)))
+
+;;;###autoload
+(defun ast-grep-outline ()
+  "Jump to a symbol in the current file via `ast-grep outline'.
+Dispatch to `consult-imenu' when available, otherwise `imenu'.  This is a
+one-shot entry point: it does not require `ast-grep-outline-mode' and
+leaves the buffer's own imenu configuration untouched."
+  (interactive)
+  (unless (ast-grep--executable-available-p)
+    (error "The ast-grep executable not found. Please install ast-grep"))
+  (unless buffer-file-name
+    (user-error "Current buffer is not visiting a file"))
+  (let ((saved-fn (if (local-variable-p 'imenu-create-index-function)
+                      imenu-create-index-function
+                    'unset))
+        (saved-alist imenu--index-alist)
+        (cache-local (and (boundp 'consult-imenu--cache)
+                          (local-variable-p 'consult-imenu--cache)))
+        (saved-cache (and (boundp 'consult-imenu--cache) consult-imenu--cache))
+        (imenu-auto-rescan t))
+    (unwind-protect
+        (progn
+          (setq-local imenu-create-index-function
+                      #'ast-grep--outline-imenu-index)
+          (setq imenu--index-alist nil)
+          (if (and (require 'consult-imenu nil t) (fboundp 'consult-imenu))
+              (progn
+                ;; consult-imenu caches per `buffer-modified-tick' and ignores
+                ;; `imenu--index-alist', so clear its cache to force a recompute
+                ;; against our index.
+                (setq-local consult-imenu--cache nil)
+                (call-interactively #'consult-imenu))
+            (call-interactively #'imenu)))
+      (if (eq saved-fn 'unset)
+          (kill-local-variable 'imenu-create-index-function)
+        (setq-local imenu-create-index-function saved-fn))
+      (setq imenu--index-alist saved-alist)
+      (when (boundp 'consult-imenu--cache)
+        (if cache-local
+            (setq-local consult-imenu--cache saved-cache)
+          (kill-local-variable 'consult-imenu--cache))))))
+
+(provide 'ast-grep-outline)
+
+;;; ast-grep-outline.el ends here

--- a/ast-grep-outline.el
+++ b/ast-grep-outline.el
@@ -206,11 +206,12 @@ the buffer to keep positions accurate."
 ;;;###autoload
 (defun ast-grep-outline ()
   "Jump to a symbol in the current file via `ast-grep outline'.
-Pick the picker the way `ast-grep-search' picks a backend: `counsel-imenu'
-when `ivy-mode' is active and counsel is available, otherwise
-`consult-imenu', otherwise the built-in `imenu'.  This is a one-shot entry
-point: it does not require `ast-grep-outline-mode' and leaves the buffer's
-own imenu configuration untouched."
+Pick the picker the way `ast-grep-search' picks a backend: when `ivy-mode'
+is active use `counsel-imenu' (or the built-in `imenu' if counsel is
+unavailable, never `consult-imenu'); otherwise use `consult-imenu' when
+available, else `imenu'.  This is a one-shot entry point: it does not
+require `ast-grep-outline-mode' and leaves the buffer's own imenu
+configuration untouched."
   (interactive)
   (unless (ast-grep--executable-available-p)
     (error "The ast-grep executable not found. Please install ast-grep"))
@@ -230,11 +231,13 @@ own imenu configuration untouched."
                       #'ast-grep--outline-imenu-index)
           (setq imenu--index-alist nil)
           (cond
-           ;; Mirror `ast-grep-search' backend selection: ivy users get
-           ;; counsel-imenu, which reads the same `imenu--index-alist'.
-           ((and (bound-and-true-p ivy-mode)
-                 (require 'counsel nil t) (fboundp 'counsel-imenu))
-            (call-interactively #'counsel-imenu))
+           ;; Mirror `ast-grep--select-backend': under ivy-mode use
+           ;; counsel-imenu, else the built-in imenu (ivy drives it) --- never
+           ;; consult.  Both read the same `imenu--index-alist'.
+           ((bound-and-true-p ivy-mode)
+            (if (and (require 'counsel nil t) (fboundp 'counsel-imenu))
+                (call-interactively #'counsel-imenu)
+              (call-interactively #'imenu)))
            ((and (require 'consult-imenu nil t) (fboundp 'consult-imenu))
             ;; consult-imenu caches per `buffer-modified-tick' and ignores
             ;; `imenu--index-alist', so clear its cache to force a recompute

--- a/ast-grep.el
+++ b/ast-grep.el
@@ -43,6 +43,7 @@
 (require 'project)
 (require 'ast-grep-core)
 (require 'ast-grep-sync)
+(require 'ast-grep-outline)
 
 (defvar ivy-mode nil)
 

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -309,6 +309,24 @@ binary predates 0.44.0 or is missing entirely."
         (ast-grep-outline)
         (should (eq called 'counsel))))))
 
+(ert-deftest ast-grep-outline-test-command-ivy-without-counsel-uses-imenu ()
+  "ivy-mode active but counsel missing falls to imenu, never consult.
+Runs in the consult sandbox, where consult is present but counsel is not."
+  (skip-unless (and (require 'consult-imenu nil t)
+                    (not (require 'counsel nil t))))
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (let ((ivy-mode t)
+          (called nil))
+      (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+                 (lambda () t))
+                ((symbol-function 'consult-imenu)
+                 (lambda (&rest _) (interactive) (setq called 'consult)))
+                ((symbol-function 'imenu)
+                 (lambda (&rest _) (interactive) (setq called 'imenu))))
+        (ast-grep-outline)
+        (should (eq called 'imenu))))))
+
 (provide 'ast-grep-outline-test)
 
 ;;; ast-grep-outline-test.el ends here

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -135,7 +135,7 @@ installed in the current sandbox."
   (with-temp-buffer
     (setq buffer-file-name "x.ts")
     (setq-local imenu--index-alist 'sentinel)
-    (let ((called nil))
+    (let ((called nil) (ivy-mode nil))
       (cl-letf (((symbol-function 'ast-grep--executable-available-p)
                  (lambda () t))
                 ((symbol-function 'imenu)
@@ -294,6 +294,20 @@ binary predates 0.44.0 or is missing entirely."
         (should (eq imenu-create-index-function
                     #'ast-grep--outline-imenu-index))
         (should-not (funcall imenu-create-index-function))))))
+
+(ert-deftest ast-grep-outline-test-command-dispatches-counsel-when-ivy ()
+  "With `ivy-mode' active and counsel available, dispatch to counsel-imenu."
+  (skip-unless (require 'counsel nil t))
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (let ((ivy-mode t)
+          (called nil))
+      (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+                 (lambda () t))
+                ((symbol-function 'counsel-imenu)
+                 (lambda (&rest _) (interactive) (setq called 'counsel))))
+        (ast-grep-outline)
+        (should (eq called 'counsel))))))
 
 (provide 'ast-grep-outline-test)
 

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -1,0 +1,271 @@
+;;; ast-grep-outline-test.el --- Outline/imenu tests for ast-grep.el -*- lexical-binding: t -*-
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Tests for the ast-grep outline imenu integration.
+
+;;; Code:
+
+(require 'ast-grep-test-helper)
+(require 'ast-grep-outline)
+
+(defconst ast-grep-outline-test--sample-ts
+  (expand-file-name "sample.ts" ast-grep-test--fixtures-dir)
+  "TypeScript fixture exercised by the real outline binary.")
+
+(defconst ast-grep-outline-test--stream
+  (concat
+   "{\"path\":\"x.ts\",\"language\":\"TypeScript\",\"items\":["
+   "{\"symbolType\":\"class\",\"name\":\"Widget\","
+   "\"range\":{\"start\":{\"line\":0,\"column\":0}},\"members\":["
+   "{\"symbolType\":\"field\",\"name\":\"id\","
+   "\"range\":{\"start\":{\"line\":1,\"column\":2}}},"
+   "{\"symbolType\":\"method\",\"name\":\"render\","
+   "\"range\":{\"start\":{\"line\":2,\"column\":2}}}]},"
+   "{\"symbolType\":\"function\",\"name\":\"greet\","
+   "\"range\":{\"start\":{\"line\":4,\"column\":0}}},"
+   "{\"symbolType\":\"constant\",\"name\":\"K\","
+   "\"range\":{\"start\":{\"line\":5,\"column\":0}}}]}")
+  "Hand-built outline stream matching `ast-grep-outline-test--insert-source'.")
+
+(defun ast-grep-outline-test--insert-source ()
+  "Insert source text whose lines/columns line up with the fixture stream."
+  (insert "class Widget {\n"
+          "  id;\n"
+          "  render() {}\n"
+          "}\n"
+          "function greet() {}\n"
+          "const K = 1;\n"))
+
+(defun ast-grep-outline-test--pos (line column)
+  "Return the buffer position for 0-based LINE and COLUMN."
+  (save-excursion
+    (goto-char (point-min))
+    (forward-line line)
+    (forward-char column)
+    (point)))
+
+(ert-deftest ast-grep-outline-test-build-command ()
+  "The outline command targets a single file with stream JSON."
+  (let ((ast-grep-executable "ast-grep"))
+    (should (equal (ast-grep--build-outline-command "/tmp/a.ts")
+                   '("ast-grep" "outline" "--json=stream" "/tmp/a.ts")))))
+
+(ert-deftest ast-grep-outline-test-group-title ()
+  "Known symbol types map to titles; unknown types fall back to capitalize."
+  (should (equal (ast-grep--outline-group-title "class") "Classes"))
+  (should (equal (ast-grep--outline-group-title "method") "Methods"))
+  (should (equal (ast-grep--outline-group-title "widget") "Widget")))
+
+(ert-deftest ast-grep-outline-test-parse ()
+  "Parsing collects items and tolerates blank and malformed lines."
+  (let* ((output (concat ast-grep-outline-test--stream "\nnot-json\n"))
+         (items (ast-grep--outline-parse output)))
+    (should (= (length items) 3))
+    (should (equal (plist-get (car items) :name) "Widget"))
+    (should (= (length (plist-get (car items) :members)) 2)))
+  (should-not (ast-grep--outline-parse nil))
+  (should-not (ast-grep--outline-parse ""))
+  (should-not (ast-grep--outline-parse "not-json")))
+
+(ert-deftest ast-grep-outline-test-index-structure ()
+  "The imenu index groups by type, qualifies members, and keeps source order."
+  (with-temp-buffer
+    (ast-grep-outline-test--insert-source)
+    (cl-letf (((symbol-function 'ast-grep--run-outline)
+               (lambda (_file) ast-grep-outline-test--stream)))
+      (setq buffer-file-name "x.ts")
+      (let ((index (ast-grep--outline-imenu-index)))
+        ;; Groups appear in canonical order, not source order.
+        (should (equal (mapcar #'car index)
+                       '("Classes" "Functions" "Methods" "Fields" "Constants")))
+        (should (equal (cdr (assoc "Classes" index))
+                       (list (cons "Widget" (ast-grep-outline-test--pos 0 0)))))
+        (should (equal (cdr (assoc "Methods" index))
+                       (list (cons "Widget.render"
+                                   (ast-grep-outline-test--pos 2 2)))))
+        (should (equal (cdr (assoc "Fields" index))
+                       (list (cons "Widget.id"
+                                   (ast-grep-outline-test--pos 1 2)))))
+        (should (equal (cdr (assoc "Functions" index))
+                       (list (cons "greet" (ast-grep-outline-test--pos 4 0)))))))))
+
+(ert-deftest ast-grep-outline-test-index-requires-file ()
+  "A buffer with no file yields no index rather than an error."
+  (with-temp-buffer
+    (insert "class A {}")
+    (should-not buffer-file-name)
+    (should-not (ast-grep--outline-imenu-index))))
+
+(ert-deftest ast-grep-outline-test-mode-installs-and-restores-default ()
+  "Enabling sets the local index function; disabling restores the default."
+  (with-temp-buffer
+    (should-not (local-variable-p 'imenu-create-index-function))
+    (ast-grep-outline-mode 1)
+    (should (eq imenu-create-index-function #'ast-grep--outline-imenu-index))
+    (should (local-variable-p 'imenu-create-index-function))
+    (ast-grep-outline-mode -1)
+    (should-not (local-variable-p 'imenu-create-index-function))))
+
+(ert-deftest ast-grep-outline-test-mode-restores-prior-local ()
+  "Disabling restores a pre-existing buffer-local index function."
+  (with-temp-buffer
+    (setq-local imenu-create-index-function #'ignore)
+    (ast-grep-outline-mode 1)
+    (should (eq imenu-create-index-function #'ast-grep--outline-imenu-index))
+    (ast-grep-outline-mode -1)
+    (should (eq imenu-create-index-function #'ignore))))
+
+(ert-deftest ast-grep-outline-test-command-requires-file ()
+  "`ast-grep-outline' refuses to run outside a file-visiting buffer."
+  (with-temp-buffer
+    (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+               (lambda () t)))
+      (should-error (ast-grep-outline) :type 'user-error))))
+
+(ert-deftest ast-grep-outline-test-command-dispatches-picker ()
+  "`ast-grep-outline' dispatches to a picker and restores imenu state.
+Both pickers are stubbed so the test is agnostic to whether consult is
+installed in the current sandbox."
+  ;; Load consult-imenu first (when available) so the require inside
+  ;; `ast-grep-outline' is a no-op and does not clobber the stub below.
+  (require 'consult-imenu nil t)
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (setq-local imenu--index-alist 'sentinel)
+    (let ((called nil))
+      (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+                 (lambda () t))
+                ((symbol-function 'imenu)
+                 (lambda (&rest _) (interactive) (setq called 'imenu)))
+                ((symbol-function 'consult-imenu)
+                 (lambda (&rest _) (interactive) (setq called 'consult))))
+        (ast-grep-outline)
+        (should (memq called '(imenu consult)))
+        ;; The one-shot leaves the buffer's imenu configuration untouched.
+        (should-not (local-variable-p 'imenu-create-index-function))
+        (should (eq imenu--index-alist 'sentinel))))))
+
+(ert-deftest ast-grep-outline-test-real-binary-index ()
+  "The real outline binary produces the expected index for sample.ts."
+  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (let ((buffer (find-file-noselect ast-grep-outline-test--sample-ts)))
+    (unwind-protect
+        (with-current-buffer buffer
+          (let ((index (ast-grep--outline-imenu-index)))
+            (should (equal (mapcar #'car index)
+                           '("Classes" "Interfaces" "Functions"
+                             "Methods" "Constructors" "Fields" "Constants")))
+            (should (equal (mapcar #'car (cdr (assoc "Fields" index)))
+                           '("Point.x" "Point.y" "Widget.id")))
+            (should (equal (mapcar #'car (cdr (assoc "Classes" index)))
+                           '("Widget")))
+            (should (equal (mapcar #'car (cdr (assoc "Constructors" index)))
+                           '("Widget.constructor")))
+            ;; Positions land on the symbol they name.
+            (goto-char (cdr (assoc "Widget" (cdr (assoc "Classes" index)))))
+            (should (looking-at-p "export class Widget"))
+            (goto-char (cdr (assoc "greet" (cdr (assoc "Functions" index)))))
+            (should (looking-at-p "export function greet"))))
+      (kill-buffer buffer))))
+
+(ert-deftest ast-grep-outline-test-parse-multiple-objects ()
+  "Items from every JSON object (multi-file output) are collected."
+  (let* ((second (concat
+                  "{\"path\":\"y.ts\",\"items\":["
+                  "{\"symbolType\":\"function\",\"name\":\"farewell\","
+                  "\"range\":{\"start\":{\"line\":0,\"column\":0}}}]}"))
+         (output (concat ast-grep-outline-test--stream "\n" second "\nnot-json\n"))
+         (items (ast-grep--outline-parse output))
+         (names (mapcar (lambda (i) (plist-get i :name)) items)))
+    (should (= (length items) 4))
+    (should (member "Widget" names))
+    (should (member "farewell" names))))
+
+(ert-deftest ast-grep-outline-test-flatten-skips-non-string-name ()
+  "Items whose name is not a string (e.g. JSON null) are skipped."
+  (with-temp-buffer
+    (insert "a\nb\nc\nd\n")
+    (let* ((stream (concat
+                    "{\"path\":\"x.ts\",\"items\":["
+                    "{\"symbolType\":\"function\",\"name\":null,"
+                    "\"range\":{\"start\":{\"line\":0,\"column\":0}}},"
+                    "{\"symbolType\":\"class\",\"name\":\"Widget\","
+                    "\"range\":{\"start\":{\"line\":1,\"column\":0}},\"members\":["
+                    "{\"symbolType\":\"method\",\"name\":null,"
+                    "\"range\":{\"start\":{\"line\":2,\"column\":0}}}]}]}"))
+           (flat (ast-grep--outline-flatten
+                  (ast-grep--outline-parse stream) nil)))
+      (should (equal (mapcar (lambda (entry) (nth 1 entry)) flat) '("Widget"))))))
+
+(ert-deftest ast-grep-outline-test-dedupes-duplicate-names ()
+  "Same-name siblings get distinct, individually reachable labels."
+  (with-temp-buffer
+    (insert "x\ny\nz\n")
+    (setq buffer-file-name "x.rs")
+    (let* ((stream (concat
+                    "{\"path\":\"x.rs\",\"items\":["
+                    "{\"symbolType\":\"object\",\"name\":\"A\","
+                    "\"range\":{\"start\":{\"line\":0,\"column\":0}}},"
+                    "{\"symbolType\":\"object\",\"name\":\"A\","
+                    "\"range\":{\"start\":{\"line\":1,\"column\":0}}}]}"))
+           (index (cl-letf (((symbol-function 'ast-grep--run-outline)
+                             (lambda (_file) stream)))
+                    (ast-grep--outline-imenu-index)))
+           (objects (cdr (assoc "Objects" index))))
+      (should (equal (mapcar #'car objects) '("A" "A<2>")))
+      ;; Each label resolves to its own position via `assoc'.
+      (should (= (cdr (assoc "A" objects)) (ast-grep-outline-test--pos 0 0)))
+      (should (= (cdr (assoc "A<2>" objects))
+                 (ast-grep-outline-test--pos 1 0))))))
+
+(ert-deftest ast-grep-outline-test-group-unknown-type-sorts-last ()
+  "Groups for symbol types absent from the title map sort after known ones."
+  (let ((index (ast-grep--outline-group
+                '(("widget" "Gizmo" 1)
+                  ("class" "Widget" 2)
+                  ("function" "greet" 3)))))
+    (should (equal (mapcar #'car index) '("Classes" "Functions" "Widget")))))
+
+(ert-deftest ast-grep-outline-test-index-degrades-on-error ()
+  "A failing outline run yields an empty index instead of signalling."
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (let ((inhibit-message t))
+      (cl-letf (((symbol-function 'ast-grep--run-outline)
+                 (lambda (_file) (error "boom"))))
+        (should-not (ast-grep--outline-imenu-index))))))
+
+(ert-deftest ast-grep-outline-test-mode-reentrant-enable ()
+  "Enabling twice then disabling still removes the buffer-local index fn."
+  (with-temp-buffer
+    (ast-grep-outline-mode 1)
+    (ast-grep-outline-mode 1)
+    (ast-grep-outline-mode -1)
+    (should-not (local-variable-p 'imenu-create-index-function))))
+
+(ert-deftest ast-grep-outline-test-command-clears-consult-cache ()
+  "The one-shot busts consult-imenu's per-tick cache, then restores it."
+  (skip-unless (require 'consult-imenu nil t))
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (let ((stale (cons 0 '(("stale" . 1))))
+          cache-at-dispatch)
+      (setq-local consult-imenu--cache stale)
+      (cl-letf (((symbol-function 'ast-grep--executable-available-p)
+                 (lambda () t))
+                ((symbol-function 'consult-imenu)
+                 (lambda (&rest _)
+                   (interactive)
+                   (setq cache-at-dispatch consult-imenu--cache))))
+        (ast-grep-outline)
+        ;; consult saw a cleared cache, so it recomputes against our index...
+        (should-not cache-at-dispatch)
+        ;; ...and the buffer's prior cache is restored afterwards.
+        (should (equal consult-imenu--cache stale))))))
+
+(provide 'ast-grep-outline-test)
+
+;;; ast-grep-outline-test.el ends here

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -266,6 +266,35 @@ installed in the current sandbox."
         ;; ...and the buffer's prior cache is restored afterwards.
         (should (equal consult-imenu--cache stale))))))
 
+(ert-deftest ast-grep-outline-test-mode-invalidates-imenu-cache ()
+  "Toggling the mode clears a stale imenu index left by the prior source."
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (setq-local imenu--index-alist '(("old" . 1)))
+    (ast-grep-outline-mode 1)
+    ;; Enabling drops the index built by the previous source.
+    (should-not imenu--index-alist)
+    (setq-local imenu--index-alist '(("ours" . 2)))
+    (ast-grep-outline-mode -1)
+    ;; Disabling drops our index so the restored source rebuilds.
+    (should-not imenu--index-alist)))
+
+(ert-deftest ast-grep-outline-test-degrades-without-outline-support ()
+  "An ast-grep without `outline' yields an empty index, never an error.
+This keeps the rest of the package (search/rewrite) usable when the
+binary predates 0.44.0 or is missing entirely."
+  (with-temp-buffer
+    (setq buffer-file-name "x.ts")
+    (let ((inhibit-message t))
+      (cl-letf (((symbol-function 'ast-grep--run-outline)
+                 (lambda (_file)
+                   (error "exit code 2: unrecognized subcommand 'outline'"))))
+        (ast-grep-outline-mode 1)
+        ;; imenu consumers call this; it returns an empty index, not an error.
+        (should (eq imenu-create-index-function
+                    #'ast-grep--outline-imenu-index))
+        (should-not (funcall imenu-create-index-function))))))
+
 (provide 'ast-grep-outline-test)
 
 ;;; ast-grep-outline-test.el ends here

--- a/tests/ast-grep-outline-test.el
+++ b/tests/ast-grep-outline-test.el
@@ -150,7 +150,7 @@ installed in the current sandbox."
 
 (ert-deftest ast-grep-outline-test-real-binary-index ()
   "The real outline binary produces the expected index for sample.ts."
-  (skip-unless (ast-grep-test--ast-grep-available-p))
+  (skip-unless (ast-grep-test--outline-available-p))
   (let ((buffer (find-file-noselect ast-grep-outline-test--sample-ts)))
     (unwind-protect
         (with-current-buffer buffer

--- a/tests/ast-grep-test-helper.el
+++ b/tests/ast-grep-test-helper.el
@@ -37,6 +37,12 @@
   "Return non-nil when the ast-grep binary is on PATH."
   (executable-find "ast-grep"))
 
+(defun ast-grep-test--outline-available-p ()
+  "Return non-nil when the ast-grep binary supports the `outline' subcommand.
+ast-grep gained `outline' in 0.44.0; older binaries exit non-zero."
+  (and (ast-grep-test--ast-grep-available-p)
+       (eq 0 (call-process "ast-grep" nil nil nil "outline" "--help"))))
+
 (defvar ast-grep-test--consult-available
   (require 'consult nil t)
   "Non-nil if consult is loadable during this test run.")

--- a/tests/fixtures/sample.ts
+++ b/tests/fixtures/sample.ts
@@ -1,0 +1,20 @@
+export const GREETING = "hi";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export class Widget {
+  id: number;
+  constructor(id: number) {
+    this.id = id;
+  }
+  render(): string {
+    return "w";
+  }
+}
+
+export function greet(name: string): string {
+  return `${GREETING} ${name}`;
+}

--- a/tests/run-tests.el
+++ b/tests/run-tests.el
@@ -16,6 +16,7 @@
 
 (defconst ast-grep-test--all-test-files
   '("ast-grep-core-test.el"
+    "ast-grep-outline-test.el"
     "ast-grep-sync-test.el"
     "ast-grep-consult-test.el"
     "ast-grep-ivy-test.el"
@@ -28,12 +29,15 @@
       ast-grep-test--all-test-files
     (pcase (getenv "AST_GREP_TEST_BACKEND")
       ("sync" '("ast-grep-core-test.el"
+                "ast-grep-outline-test.el"
                 "ast-grep-sync-test.el"
                 "ast-grep-entry-test.el"))
       ("consult" '("ast-grep-core-test.el"
+                   "ast-grep-outline-test.el"
                    "ast-grep-consult-test.el"
                    "ast-grep-entry-test.el"))
       ("ivy" '("ast-grep-core-test.el"
+               "ast-grep-outline-test.el"
                "ast-grep-ivy-test.el"
                "ast-grep-entry-test.el"))
       ("full" ast-grep-test--all-test-files)
@@ -49,12 +53,15 @@
   (or (getenv "AST_GREP_TEST_SELECTOR")
       (pcase (getenv "AST_GREP_TEST_BACKEND")
         ("sync" '(or "^ast-grep-core-test-"
+                    "^ast-grep-outline-test-"
                     "^ast-grep-sync-test-"
                     "^ast-grep-entry-test-"))
         ("consult" '(or "^ast-grep-core-test-"
+                       "^ast-grep-outline-test-"
                        "^ast-grep-consult-test-"
                        "^ast-grep-entry-test-"))
         ("ivy" '(or "^ast-grep-core-test-"
+                   "^ast-grep-outline-test-"
                    "^ast-grep-ivy-test-"
                    "^ast-grep-entry-test-"))
         ("full" t)


### PR DESCRIPTION
## ast-grep outline → imenu

In-file symbol navigation powered by `ast-grep outline` (ast-grep 0.44.0+). The outline is surfaced as a standard imenu index, so it works out of the box with `consult-imenu`, `counsel-imenu`, `imenu`, and `imenu-list` — no extra glue.

### Commands

- **`ast-grep-outline`** — one-shot jump to a symbol in the current file. Uses `consult-imenu` when available, falls back to `imenu`.
- **`ast-grep-outline-mode`** — make ast-grep the buffer's imenu source (e.g. on a language hook), so every imenu consumer lists ast-grep's symbols.

### Behavior

- Symbols grouped by kind (Classes, Functions, Methods, Fields, …); members qualified with their parent (`Widget.render`).
- Same-name siblings disambiguated so every entry stays reachable.
- Covers the languages ast-grep ships outline rules for: TS/JS, Python, Go, Rust, Java, …
- Missing/old ast-grep degrades to an empty index instead of erroring.

### Demo


https://github.com/user-attachments/assets/e272a250-0926-4a8e-9b66-24ef373bdd3a

